### PR TITLE
Add programmatic validator builder using Java method references

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,25 @@ __README Index__
 
 1. [Project set up](#project-set-up)
 2. [Usage](#usage)
-    1. [Business Object](#business-object)
-    2. [Validation](#validation)
-    3. [Business rules](#business-rules)
-    4. [Business members composition](#business-member-composition)
-    5. [Business object inheritance](#business-object-inheritance)
-    6. [Default rules](#default-rules)
+   1. [usage with annotations](#usage-with-annotations)
+       1. [Business Object](#business-object)
+       2. [Validation](#validation)
+       3. [Business rules](#business-rules)
+       4. [Business members composition](#business-member-composition)
+       5. [Business object inheritance](#business-object-inheritance)
+       6. [Default rules](#default-rules)
+   2. [Usage with manual builder](#usage-with-manual-builder)
+      1. [Programmatic business rules](#programmatic-business-rules)
+      2. [Programmatic business members](#programmatic-business-members)
+      3. [Programmatic members with inheritance](#programmatic-members-with-inheritance)
+      4. [Reusing builder](#reusing-builder)
+      5. [Complex use cases](#complex-use-cases)
 3. [Ideas behind BValid](#ideas-behind-bvalid)
 4. [Sources and build](#sources-and-build)
 5. [Contribute](#contribute)
 6. [License](#license)
 
-## Project set-up
+## 1. Project set-up
 
 __BValid__ is available on Maven Central Repository
 
@@ -38,7 +45,9 @@ __BValid__ is available on Maven Central Repository
 __BValid__ is a validation tool running a collection of assertions or rules on a business object to assess whether this
 object is valid or not.
 
-### Business Object
+### Usage with Annotations
+
+#### Business Object
 
 When using __BValid__, a business object is a Java class annotated with `@BusinessObject` that has at least one business
 rule or one business member.
@@ -57,8 +66,9 @@ public class Author {
       return name;
    }
 
-   public void setName(String name) {
+   public Author setName(String name) {
       this.name = name;
+      return this;
    }
 
    @BusinessRule("Author's name must be defined.")
@@ -165,8 +175,9 @@ public class Book {
       return author;
    }
 
-   public void setAuthor(Author author) {
+   public Book setAuthor(Author author) {
       this.author = author;
+      return this;
    }
 
    @BusinessRule("Author must be defined.")
@@ -197,6 +208,11 @@ public class Library {
    public List<Book> getBooks() {
       return books;
    }
+   
+    public Library setBooks(List<Book> books) {
+        this.books = books;
+        return this;
+    }
 }
 ```
 
@@ -223,8 +239,14 @@ public class Comic extends Book {
       return artist;
    }
 
-   public void setArtist(String artist) {
+   public Comic setArtist(String artist) {
       this.artist = artist;
+      return this;
+   }
+   @Override
+   public Comic setAuthor(Author author) { // override parent setter for java 8 style
+      super.setAuthor(author);
+      return this;
    }
 
    @BusinessRule("Artist must be defined if present.")
@@ -279,6 +301,246 @@ public class DefaultRulesDemo {
 
 To avoid too much coupling with __BValid__, you should encapsulate `BasicRules` behind an interface. See adapter
 pattern.
+
+### Usage with Manual Builder
+
+To support the extensibility and more complex use cases, __BValid__ provides a builder to create a `BValidator` instance
+programmatically.
+
+#### Programmatic business rules
+
+The following example shows how to create a `BValidator` for the `Author` class with no business members.
+
+```java
+
+import io.github.ceoche.bvalid.BValidator;
+import io.github.ceoche.bvalid.BValidatorManualBuilder;
+import io.github.ceoche.bvalid.BusinessObject;
+import io.github.ceoche.bvalid.ObjectResult;
+
+class Example {
+
+   public static void main(String[] args) {
+      BValidator<Author> bValidator = new BValidatorManualBuilder<>(Author.class)
+              .setBusinessObjectName("Author") // optional, but we recommend to set it for better error messages.
+              .addBusinessRule(Author::isNameValid, "Author's name must be defined.")
+              .build();
+
+      Author author = new Author();
+      author.setName("John Doe");
+
+      ObjectResult result = bValidator.validate(author);
+      if (result.isValid()) {
+         doSomething();
+      } else {
+         for (RuleResult ruleResult : result.getRuleFailures()) {
+            // handle error bad example:
+            System.out.println(ruleResult.toString());
+         }
+      }
+   }
+}
+
+```
+
+> The business object name is optional, but we recommend to set it at least for the root business object to get better error messages.
+
+
+#### Programmatic business members
+
+Aggregates and associations can be validated by adding business members to the builder.
+
+The add member method takes: 
+- The name of the member 
+- The getter method of the member
+- The validators builders for the member and/or its subtypes.
+
+In this example will suppose having a `Book` class with an `Author` member, with no subtypes.
+
+```java
+
+import io.github.ceoche.bvalid.BValidator;
+import io.github.ceoche.bvalid.BValidatorManualBuilder;
+import io.github.ceoche.bvalid.BusinessObject;
+import io.github.ceoche.bvalid.ObjectResult;
+
+class Example {
+
+   public static void main(String[] args) {
+       BValidator<Book> bValidator = new BValidatorManualBuilder<>(Book.class)
+               .setBusinessObjectName("Book") // optional, but we recommend to set it for better error messages.
+               .addRule(Book::isAuthorValid, "Author must be not null.")
+               .addMember("author", Book::getAuthor, 
+                       new BValidatorManualBuilder<>(Author.class)
+                               .addRule(Author::isNameValid, "Author's name must be defined.")
+               )
+               .build();
+       
+       // use the validator
+   }
+}
+
+```
+
+The manual builder supports multiple cardinality for collections and arrays the same way as single members.
+
+```java
+import io.github.ceoche.bvalid.BValidator;
+import io.github.ceoche.bvalid.BValidatorManualBuilder;
+import io.github.ceoche.bvalid.BusinessObject;
+import io.github.ceoche.bvalid.ObjectResult;
+
+class Example {
+
+   public static void main(String[] args) {
+       BValidator<Library> bValidator = new BValidatorManualBuilder<>(Library.class)
+               .setBusinessObjectName("Library") // optional, but we recommend to set it for better error messages.
+               .addMember("books", Library::getBooks, 
+                       new BValidatorManualBuilder<>(Book.class)
+                               .addRule(Book::isAuthorValid, "Author must be defined.")
+                               .addMember("author", Book::getAuthor, 
+                                       new BValidatorManualBuilder<>(Author.class)
+                                               .addRule(Author::isNameValid, "Author's name must be defined.")
+                               )
+               )
+               .build();
+       
+       // Instantiate a Library with different type of books
+
+      Library library = new Library().setBooks(Arrays.asList(
+              new Book()
+                      .setAuthor(new Author().setName("John Doe")),
+              new Book()
+                      .setAuthor(new Author().setName("Jane Doe"))
+              )
+      );
+         
+      // use the validator
+      ObjectResult result = bValidator.validate(library);
+
+      System.out.println(result);
+      
+      // Output:
+      /*
+         Library.books[0] Author must be defined. => true
+         Library.books[0].author Author's name must be defined. => true
+         Library.books[1] Author must be defined. => true
+         Library.books[1].author Author's name must be defined. => true
+       */
+      
+   }
+}
+
+
+```
+
+#### Programmatic members with inheritance
+
+Polymorphism context is supported by the manual builder. although, the possible implementations should be provided 
+at build time. This will be enhanced in future versions to support more extensibility.
+
+Taking the example of the `Book` class, we can add a `Comic` class that extends `Book` and add a validator builder 
+for the `Comic` implementation to the Library validator builder. 
+
+```java
+import io.github.ceoche.bvalid.BValidator;
+import io.github.ceoche.bvalid.BValidatorManualBuilder;
+import io.github.ceoche.bvalid.BusinessObject;
+import io.github.ceoche.bvalid.ObjectResult;
+
+class Example {
+
+   public static void main(String[] args) {
+       BValidator<Library> bValidator = new BValidatorManualBuilder<>(Library.class)
+               .setBusinessObjectName("Library") // optional, but we recommend to set it for better error messages.
+               .addMember("books", Library::getBooks, 
+                       new BValidatorManualBuilder<>(Book.class)
+                               .addRule(Book::isAuthorValid, "Author must be defined.")
+                               .addMember("author", Book::getAuthor, 
+                                       new BValidatorManualBuilder<>(Author.class)
+                                               .addRule(Author::isNameValid, "Author's name must be defined.")
+                               ),
+                       new BValidatorManualBuilder<>(Comic.class)  // Add builder for the new Comic subtype
+                               .addRule(Comic::isArtistValid, "Author must be defined.")
+                               .addRule(Comic::isAuthorValid, "Author must be defined.")
+                               .addMember("author", Comic::getAuthor, 
+                                       new BValidatorManualBuilder<>(Author.class)
+                                               .addRule(Author::isNameValid, "Author's name must be defined.")
+                               )
+               )
+               .build();
+
+      // Instantiate a Library with different type of books
+
+      Library library = new Library().setBooks(Arrays.asList(
+                      new Book()
+                              .setAuthor(new Author().setName("John Doe")),
+                      new Comic()
+                              .setAuthor(new Author().setName("Jane Doe"))
+                                .setArtist("Jack Doe")
+              )
+      );
+
+      // use the validator
+      ObjectResult result = bValidator.validate(library);
+
+      System.out.println(result);
+
+      // Output:
+      /*
+         Library.books[0] Author must be defined. => true
+         Library.books[0].author Author's name must be defined. => true
+         Library.books[1] Artist must be defined. => true
+         Library.books[1] Author must be defined. => true
+         Library.books[1].author Author's name must be defined. => true
+       */
+      
+   }
+}
+```
+
+#### Reusing builder
+
+As you can see in the previous example, the builder for `Author` is used in multiple places. It is possible to reuse
+the builder by extracting it to a variable and reusing it.
+
+```java
+import io.github.ceoche.bvalid.BValidator;
+import io.github.ceoche.bvalid.BValidatorManualBuilder;
+import io.github.ceoche.bvalid.BusinessObject;
+import io.github.ceoche.bvalid.ObjectResult;
+
+class Example {
+
+   public static void main(String[] args) {
+       BValidatorManualBuilder<Author> authorValidatorBuilder = new BValidatorManualBuilder<>(Author.class)
+               .addRule(Author::isNameValid, "Author's name must be defined.");
+       BValidator<Library> bValidator = new BValidatorManualBuilder<>(Library.class)
+               .setBusinessObjectName("Library") // optional, but we recommend to set it for better error messages.
+               .addMember("books", Library::getBooks, 
+                       new BValidatorManualBuilder<>(Book.class)
+                               .addRule(Book::isAuthorValid, "Author must be defined.")
+                               .addMember("author", Book::getAuthor, authorValidatorBuilder),
+                       new BValidatorManualBuilder<>(Comic.class)  // Add builder for the new Comic subtype
+                               .addRule(Comic::isArtistValid, "Author must be defined.")
+                               .addRule(Comic::isAuthorValid, "Author must be defined.")
+                               .addMember("author", Comic::getAuthor, authorValidatorBuilder)
+               )
+               .build();
+
+      // use the validator
+      
+      
+   }
+}
+```
+#### Complex use cases
+
+The validator support other uses cases such: 
+- Validating a recursive structure
+- Use same validator builder reference for multiple members
+- Cross recursive validation
+- ...
 
 ## Ideas behind BValid
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BValid
 
+### _WARNING: THIS IS AN OUTDATED DOCUMENTATION_
+
 __BValid__ is an open-source Java library to provide easy business rules and model validation.
 
 This project is under [Apache License, Version 2.0](#license).
@@ -73,8 +75,8 @@ Any sub-classes of a class annotated with `@BusinessObject` are also considered 
 To verify a business object, simply call the `BValidator`:
 
 ```java
-import io.github.ceoche.bvalid.ObjectResult;
 import io.github.ceoche.bvalid.BValidator;
+import io.github.ceoche.bvalid.ObjectResult;
 import io.github.ceoche.bvalid.RuleResult;
 
 public class Example {

--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ have all its valuable rules.
 
 ### Requirements
 
-* Java 11 or youngest
+* Java 17 or youngest
 * Maven 3
 
 ### Build, test and package

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
    <groupId>io.github.ceoche</groupId>
    <artifactId>bvalid</artifactId>
-   <version>0.1.1-SNAPSHOT</version>
+   <version>1.0.0-SNAPSHOT</version>
 
    <name>BValid</name>
    <description>BValid is an open-source Java library to provide easy business rules and model validation.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
    </scm>
 
    <properties>
-      <maven.compiler.source>11</maven.compiler.source>
-      <maven.compiler.target>11</maven.compiler.target>
+      <maven.compiler.source>17</maven.compiler.source>
+      <maven.compiler.target>17</maven.compiler.target>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
    </properties>
 

--- a/src/main/java/io/github/ceoche/bvalid/AbstractBValidatorBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/AbstractBValidatorBuilder.java
@@ -28,7 +28,10 @@ abstract public class AbstractBValidatorBuilder<T> implements BValidatorBuilder<
         visitedBuilders.put(this, validator);
         for (BusinessMemberBuilder<T,?> businessMemberBuilder : getMembers()) {
             if(!allBuildersAreEmpty(businessMemberBuilder.getValidatorBuilders())){
-                AbstractBValidatorBuilder<?>[] subValidatorBuilders = Arrays.stream(businessMemberBuilder.getValidatorBuilders()).map(bValidatorBuilder -> (AbstractBValidatorBuilder<?>) bValidatorBuilder).toArray(AbstractBValidatorBuilder[]::new);
+                AbstractBValidatorBuilder<?>[] subValidatorBuilders = Arrays
+                        .stream(businessMemberBuilder.getValidatorBuilders())
+                        .map(bValidatorBuilder -> (AbstractBValidatorBuilder<?>) bValidatorBuilder)
+                        .toArray(AbstractBValidatorBuilder[]::new);
                 BusinessMemberObject<T,Object> businessMemberObject = new BusinessMemberObject<>(businessMemberBuilder.getName(), businessMemberBuilder.getGetter(), new HashMap<>());
                 for(AbstractBValidatorBuilder<?> subValidatorBuilder : subValidatorBuilders){
                     if(!visitedBuilders.containsKey(subValidatorBuilder)){

--- a/src/main/java/io/github/ceoche/bvalid/AbstractBValidatorBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/AbstractBValidatorBuilder.java
@@ -2,13 +2,20 @@ package io.github.ceoche.bvalid;
 
 import java.util.*;
 
-abstract public class AbstractBValidatorBuilder<T> implements BValidatorBuilder<T> {
+/**
+ * This class contains the common logic for all BValidatorBuilders
+ * which is the engine behind building a BValidator
+ * @param <T> The type of the object to validate
+ *
+ * @author Achraf Achkari
+ */
+public abstract class AbstractBValidatorBuilder<T> implements BValidatorBuilder<T> {
 
     protected Class<T> type;
 
-    abstract public Set<BusinessRuleObject<T>> getRules();
+    public abstract Set<BusinessRuleObject<T>> getRules();
 
-    abstract public String getBusinessObjectName();
+    public abstract String getBusinessObjectName();
 
     abstract Set<BusinessMemberBuilder<T,?>> getMembers();
 

--- a/src/main/java/io/github/ceoche/bvalid/AbstractBValidatorBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/AbstractBValidatorBuilder.java
@@ -1,0 +1,48 @@
+package io.github.ceoche.bvalid;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+abstract public class AbstractBValidatorBuilder<T> implements BValidatorBuilder<T> {
+
+    abstract public Set<BusinessRuleObject<T>> getRules();
+
+    abstract public Set<BusinessMemberBuilder<T, ?>> getMembers();
+
+    abstract public String getBusinessObjectName();
+
+    public boolean isEmpty(){
+        return getRules().isEmpty() && getMembers().isEmpty();
+    }
+
+    protected final BValidator<T> build(Map<AbstractBValidatorBuilder<?>,BValidator<?>> visitedBuilders){
+        Set<BusinessMemberObject<T,?>> businessMemberObjects = new LinkedHashSet<>();
+        BValidator<T> validator = new BValidator<>(getRules(), businessMemberObjects, getBusinessObjectName());
+        visitedBuilders.put(this, validator);
+        for (BusinessMemberBuilder<T,?> businessMemberBuilder : getMembers()) {
+            if(!businessMemberBuilder.getValidatorBuilder().isEmpty()){
+                AbstractBValidatorBuilder<?> subValidatorBuilder = (AbstractBValidatorBuilder<?>) businessMemberBuilder.getValidatorBuilder();
+                if(!visitedBuilders.containsKey(subValidatorBuilder)){
+                    businessMemberObjects.add(new BusinessMemberObject<>(businessMemberBuilder.getName(),
+                            businessMemberBuilder.getGetter(),subValidatorBuilder.build(visitedBuilders)));
+                }
+                else{
+                    businessMemberObjects.add(new BusinessMemberObject<>(
+                            businessMemberBuilder.getName(),
+                            businessMemberBuilder.getGetter(),
+                            visitedBuilders.get(subValidatorBuilder)
+                    ));
+                }
+            }
+        }
+        assertBuilderNotEmpty();
+        return validator;
+    }
+
+    private void assertBuilderNotEmpty(){
+        if(isEmpty()){
+            throw new IllegalBusinessObjectException("Rules or members must be provided for a business object: " + getBusinessObjectName());
+        }
+    }
+}

--- a/src/main/java/io/github/ceoche/bvalid/AbstractBValidatorBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/AbstractBValidatorBuilder.java
@@ -1,10 +1,10 @@
 package io.github.ceoche.bvalid;
 
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 abstract public class AbstractBValidatorBuilder<T> implements BValidatorBuilder<T> {
+
+    protected Class<T> type;
 
     abstract public Set<BusinessRuleObject<T>> getRules();
 
@@ -16,33 +16,56 @@ abstract public class AbstractBValidatorBuilder<T> implements BValidatorBuilder<
         return getRules().isEmpty() && getMembers().isEmpty();
     }
 
+    public AbstractBValidatorBuilder(Class<T> type) {
+        this.type = type;
+    }
+
     protected final BValidator<T> build(Map<AbstractBValidatorBuilder<?>,BValidator<?>> visitedBuilders){
+        if(type == null){
+            throw new IllegalStateException("Type is not set");
+        }
         Set<BusinessMemberObject<T,?>> businessMemberObjects = new LinkedHashSet<>();
         BValidator<T> validator = new BValidator<>(getRules(), businessMemberObjects, getBusinessObjectName());
         visitedBuilders.put(this, validator);
         for (BusinessMemberBuilder<T,?> businessMemberBuilder : getMembers()) {
-            if(!businessMemberBuilder.getValidatorBuilder().isEmpty()){
-                AbstractBValidatorBuilder<?> subValidatorBuilder = (AbstractBValidatorBuilder<?>) businessMemberBuilder.getValidatorBuilder();
-                if(!visitedBuilders.containsKey(subValidatorBuilder)){
-                    businessMemberObjects.add(new BusinessMemberObject<>(businessMemberBuilder.getName(),
-                            businessMemberBuilder.getGetter(),subValidatorBuilder.build(visitedBuilders)));
+            if(!allBuildersAreEmpty(businessMemberBuilder.getValidatorBuilders())){
+                AbstractBValidatorBuilder<?>[] subValidatorBuilders = Arrays.stream(businessMemberBuilder.getValidatorBuilders()).map(bValidatorBuilder -> (AbstractBValidatorBuilder<?>) bValidatorBuilder).toArray(AbstractBValidatorBuilder[]::new);
+                BusinessMemberObject<T,?> businessMemberObject = new BusinessMemberObject<>(businessMemberBuilder.getName(), businessMemberBuilder.getGetter(), new HashMap<>());
+                for(AbstractBValidatorBuilder<?> subValidatorBuilder : subValidatorBuilders){
+                    if(!visitedBuilders.containsKey(subValidatorBuilder)){
+                        businessMemberObject.addValidator(subValidatorBuilder.type,subValidatorBuilder.build(visitedBuilders));
+                    }
+                    else{
+                        businessMemberObject.addValidator(subValidatorBuilder.type,visitedBuilders.get(subValidatorBuilder));
+                    }
                 }
-                else{
-                    businessMemberObjects.add(new BusinessMemberObject<>(
-                            businessMemberBuilder.getName(),
-                            businessMemberBuilder.getGetter(),
-                            visitedBuilders.get(subValidatorBuilder)
-                    ));
-                }
+                businessMemberObjects.add(businessMemberObject);
+
+            }
+            else{
+                throw new IllegalStateException("All sub validators are empty");
             }
         }
         assertBuilderNotEmpty();
         return validator;
     }
 
+
     private void assertBuilderNotEmpty(){
         if(isEmpty()){
             throw new IllegalBusinessObjectException("Rules or members must be provided for a business object: " + getBusinessObjectName());
         }
     }
+
+    private boolean allBuildersAreEmpty(BValidatorBuilder<?>[] bValidatorBuilders){
+        for (BValidatorBuilder<?> bValidatorBuilder : bValidatorBuilders) {
+            if(!bValidatorBuilder.isEmpty()){
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+
 }

--- a/src/main/java/io/github/ceoche/bvalid/AbstractBValidatorBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/AbstractBValidatorBuilder.java
@@ -8,7 +8,6 @@ abstract public class AbstractBValidatorBuilder<T> implements BValidatorBuilder<
 
     abstract public Set<BusinessRuleObject<T>> getRules();
 
-    abstract public Set<BusinessMemberBuilder<T, ?>> getMembers();
 
     abstract public String getBusinessObjectName();
 
@@ -20,7 +19,7 @@ abstract public class AbstractBValidatorBuilder<T> implements BValidatorBuilder<
         this.type = type;
     }
 
-    protected final BValidator<T> build(Map<AbstractBValidatorBuilder<?>,BValidator<?>> visitedBuilders){
+    final BValidator<T> build(Map<AbstractBValidatorBuilder<?>,BValidator<?>> visitedBuilders){
         if(type == null){
             throw new IllegalStateException("Type is not set");
         }
@@ -30,7 +29,7 @@ abstract public class AbstractBValidatorBuilder<T> implements BValidatorBuilder<
         for (BusinessMemberBuilder<T,?> businessMemberBuilder : getMembers()) {
             if(!allBuildersAreEmpty(businessMemberBuilder.getValidatorBuilders())){
                 AbstractBValidatorBuilder<?>[] subValidatorBuilders = Arrays.stream(businessMemberBuilder.getValidatorBuilders()).map(bValidatorBuilder -> (AbstractBValidatorBuilder<?>) bValidatorBuilder).toArray(AbstractBValidatorBuilder[]::new);
-                BusinessMemberObject<T,?> businessMemberObject = new BusinessMemberObject<>(businessMemberBuilder.getName(), businessMemberBuilder.getGetter(), new HashMap<>());
+                BusinessMemberObject<T,Object> businessMemberObject = new BusinessMemberObject<>(businessMemberBuilder.getName(), businessMemberBuilder.getGetter(), new HashMap<>());
                 for(AbstractBValidatorBuilder<?> subValidatorBuilder : subValidatorBuilders){
                     if(!visitedBuilders.containsKey(subValidatorBuilder)){
                         businessMemberObject.addValidator(subValidatorBuilder.type,subValidatorBuilder.build(visitedBuilders));

--- a/src/main/java/io/github/ceoche/bvalid/AbstractBValidatorBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/AbstractBValidatorBuilder.java
@@ -8,8 +8,9 @@ abstract public class AbstractBValidatorBuilder<T> implements BValidatorBuilder<
 
     abstract public Set<BusinessRuleObject<T>> getRules();
 
-
     abstract public String getBusinessObjectName();
+
+    abstract Set<BusinessMemberBuilder<T,?>> getMembers();
 
     public boolean isEmpty(){
         return getRules().isEmpty() && getMembers().isEmpty();

--- a/src/main/java/io/github/ceoche/bvalid/BValidator.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidator.java
@@ -101,13 +101,13 @@ public class BValidator<T> {
         return this.validate(array, businessObjectName, new HashSet<>());
     }
 
-    private <R> ObjectResult validate(T object, String name, Set<Object> visitedObjects) {
+    private ObjectResult validate(T object, String name, Set<Object> visitedObjects) {
         if (object == null) {
             throw new NullPointerException("The object to validate cannot be null");
         }
         final ObjectResult result = new ObjectResult(name);
-        List<RuleResult> ruleResults = validateBusinessRules(object);
-        List<ObjectResult> memberResults = this.<R>validateBusinessMembers(object, visitedObjects);
+        List<RuleResult> ruleResults = this.validateBusinessRules(object);
+        List<ObjectResult> memberResults = this.validateBusinessMembers(object, visitedObjects);
         result.addRuleResults(ruleResults);
         result.addMemberResults(memberResults);
         return result;
@@ -134,7 +134,7 @@ public class BValidator<T> {
         List<ObjectResult> results = new ArrayList<>();
         int index = -1;
         for (F object : collection) {
-            results.add(((BValidator<F>) (getValidatorByType(validators, object))).validate(object, memberName + "[" + ++index + "]", visitedObjects));
+            results.add(((BValidator<F>) getValidatorByType(validators, object)).validate(object, memberName + "[" + ++index + "]", visitedObjects));
         }
         return results;
     }
@@ -181,16 +181,12 @@ public class BValidator<T> {
         return results;
     }
 
+    // O(1) complexity for hashset
     private boolean isObjectAlreadyVisited(Object memberValue, Set<Object> visitedObjects) {
         if (memberValue == null) {
             return false;
         }
-        for (Object visitedObject : visitedObjects) {
-            if (memberValue == visitedObject) {
-                return true;
-            }
-        }
-        return false;
+        return visitedObjects.contains(memberValue);
     }
 
 

--- a/src/main/java/io/github/ceoche/bvalid/BValidator.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidator.java
@@ -198,8 +198,10 @@ public class BValidator<T>  {
             return Collections.emptyList();
         }
         if (isValidCollection(memberValue)) {
-            this.<R>castGenericCheck(((Collection<?>) memberValue).iterator().next());
-            results.addAll(this.validateMemberCollection((Collection<R>) memberValue, validator, name));
+            if(!((Collection<?>) memberValue).isEmpty()){
+                this.<R>castGenericCheck(((Collection<?>) memberValue).iterator().next());
+                results.addAll(this.validateMemberCollection((Collection<R>) memberValue, validator, name));
+            }
         } else if (isValidArray(memberValue)) {
             this.<R>castGenericCheck(((Object[]) memberValue)[0]);
             results.addAll(this.validateMemberArray((R[]) memberValue, validator, name));
@@ -211,7 +213,7 @@ public class BValidator<T>  {
     }
 
     private boolean isValidCollection(Object memberValue) {
-        return (memberValue instanceof Collection) && !((Collection<?>) memberValue).isEmpty();
+        return (memberValue instanceof Collection);
     }
 
     private boolean isValidArray(Object memberValue) {

--- a/src/main/java/io/github/ceoche/bvalid/BValidator.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidator.java
@@ -19,7 +19,7 @@ import java.util.*;
 
 /**
  * The {@link BValidator} provides method to validate business rules and members of POJO business
- * based on the rules and members provided by the {@link BValidatorBuilderImpl}.
+ * based on the rules and members provided by the {@link BValidatorManualBuilder}.
  * {@link BusinessMember}.
  *
  * @author ceoche
@@ -33,7 +33,7 @@ public class BValidator<T>  {
     private final String businessObjectName;
 
     /**
-     * Hidden constructor. Only {@link BValidatorBuilderImpl} can create a {@link BValidator}.
+     * Hidden constructor. Only {@link BValidatorManualBuilder} can create a {@link BValidator}.
      */
     BValidator(Set<BusinessRuleObject<T>> rules, Set<BusinessMemberObject<T,?>> members, String businessObjectName) {
         this.businessObjectName = businessObjectName;
@@ -115,11 +115,11 @@ public class BValidator<T>  {
         return result;
     }
 
-    private <R> List<ObjectResult> validate(Collection<T> collection, String name) {
+    private List<ObjectResult> validate(Collection<T> collection, String name) {
         List<ObjectResult> results = new ArrayList<>();
         int index = -1;
         for (T object : collection) {
-            results.add(this.<R>validate(object, name + "[" + ++index + "]"));
+            results.add(this.validate(object, name + "[" + ++index + "]"));
         }
         return results;
     }
@@ -133,7 +133,7 @@ public class BValidator<T>  {
     }
 
     private <R> List<ObjectResult> validateMemberCollection(final Collection<R> collection, final BValidator<R> validator, final String memberName) {
-        return validator.<R>validate(collection, memberName);
+        return validator.validate(collection, memberName);
     }
 
     private <R> List<ObjectResult> validateMemberArray(final R[] array, final BValidator<R> validator, final String memberName) {

--- a/src/main/java/io/github/ceoche/bvalid/BValidator.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidator.java
@@ -142,7 +142,6 @@ public class BValidator<T>  {
         final List<RuleResult> results = new ArrayList<>();
         for (final BusinessRuleObject<T> rule : rules) {
             try {
-//                if()
                 results.add(new RuleResult(rule.getId(), rule.getDescription(), rule.apply(object)));
             }
             catch (InvocationException e) {

--- a/src/main/java/io/github/ceoche/bvalid/BValidator.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidator.java
@@ -15,271 +15,210 @@
  */
 package io.github.ceoche.bvalid;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 /**
  * The {@link BValidator} provides method to validate business rules and members of POJO business
- * objects as long as they are annotated with {@link BusinessObject}, {@link BusinessRule} and
+ * based on the rules and members provided by the {@link BValidatorBuilderImpl}.
  * {@link BusinessMember}.
  *
  * @author ceoche
  */
-public class BValidator {
+public class BValidator<T>  {
 
-   /**
-    * Verify if an object annotated with {@link BusinessObject} is valid by running business
-    * rules tests methods annotated with {@link BusinessRule} and by validating all nested
-    * {@link BusinessObject} accessible through methods annotated with {@link BusinessMember}.
-    * The validation will test all business rules and store the results in an
-    * {@link ObjectResult}.
-    *
-    * @param object business object to validate.
-    * @return an {@link ObjectResult} that hold all the business rule and member results.
-    * @throws IllegalBusinessObjectException if the object is not an {@link BusinessObject}, or
-    *                                        if it has no {@link BusinessRule} nor
-    *                                        {@link BusinessMember} public methods. If one of the
-    *                                        methods annotated with {@link BusinessRule} have
-    *                                        more than zero parameters or does not return a
-    *                                        boolean value. Or if one of the methods annotated with
-    *                                        {@link BusinessMember} have more than zero parameters
-    *                                        or does not return a {@link BusinessObject} (or a
-    *                                        collection/array of it).
-    * @throws InvocationException            if an exception is raised while invoking a
-    *                                        {@link BusinessRule} or a {@link BusinessMember}
-    *                                        method. The original exception will be wrapped as
-    *                                        cause.
-    * @throws NullPointerException           if the given object is null.
-    */
-   public ObjectResult validate(final Object object) {
-      return validate(object, getBusinessObjectName(assertBusinessObjectClass(object)));
-   }
+    private final Set<BusinessRuleObject<T>> rules;
 
-   /**
-    * Verify if a collection of objects annotated with {@link BusinessObject} are valid by
-    * running business rules tests methods annotated with {@link BusinessRule} and by validating
-    * all nested {@link BusinessObject} accessible through methods annotated with
-    * {@link BusinessMember}. For each element of the collection, the validation will test all
-    * business rules and store the results in an {@link ObjectResult}.
-    *
-    * @param objects business objects to validate.
-    * @return a list of {@link ObjectResult}, one for each object.
-    * @throws IllegalBusinessObjectException if one of the object is not an {@link BusinessObject},
-    *                                        or if it has no {@link BusinessRule} nor
-    *                                        {@link BusinessMember} public methods. If one of
-    *                                        the methods annotated with {@link BusinessRule} have
-    *                                        more than zero parameters or does not return a
-    *                                        boolean value. Or if one of the methods annotated
-    *                                        with {@link BusinessMember} have more than zero
-    *                                        parameters or does not return a {@link BusinessObject}
-    *                                        (or a collection/array of it).
-    * @throws InvocationException            if an exception is raised while invoking a
-    *                                        {@link BusinessRule} or a {@link BusinessMember}
-    *                                        method. The original exception will be wrapped as
-    *                                        cause.
-    * @throws NullPointerException           if the given object is null.
-    */
-   public List<ObjectResult> validate(final Collection<?> objects) {
-      return validate(objects, objects.getClass().getSimpleName());
-   }
+    private final Set<BusinessMemberObject<T,?>> members;
 
-   /**
-    * Verify if an array of objects annotated with {@link BusinessObject} are valid by running
-    * business rules tests methods annotated with {@link BusinessRule} and by validating all nested
-    * {@link BusinessObject} accessible through methods annotated with {@link BusinessMember}.
-    * For each element of the array, the validation will test all business rules and store the
-    * results in an {@link ObjectResult}.
-    *
-    * @param objects business objects to validate.
-    * @return a list of {@link ObjectResult}, one for each object.
-    * @throws IllegalBusinessObjectException if one of the object is not an {@link BusinessObject},
-    *                                        or if it has no {@link BusinessRule} nor
-    *                                        {@link BusinessMember} public methods. If one of
-    *                                        the methods annotated with {@link BusinessRule} have
-    *                                        more than zero parameters or does not return a
-    *                                        boolean value. Or if one of the methods annotated
-    *                                        with {@link BusinessMember} have more than zero
-    *                                        parameters or does not return a {@link BusinessObject}
-    *                                        (or a collection/array of it).
-    * @throws InvocationException            if an exception is raised while invoking a
-    *                                        {@link BusinessRule} or a {@link BusinessMember}
-    *                                        method. The original exception will be wrapped as
-    *                                        cause.
-    * @throws NullPointerException           if the given object is null.
-    */
-   public List<ObjectResult> validate(final Object[] objects) {
-      return validate(objects, objects.getClass().getSimpleName());
-   }
+    private final String businessObjectName;
 
-   private List<ObjectResult> validateAnyMember(final Object object, String name) {
-      List<ObjectResult> objectResults = new ArrayList<>();
-      Class<?> objectClass = object.getClass();
-      if (isCollection(objectClass)) {
-         objectResults.addAll(validate((Collection<?>) object, name));
-      } else if (objectClass.isArray()) {
-         objectResults.addAll(validate((Object[]) object, name));
-      } else {
-         objectResults.add(validate(object, name));
-      }
-      return objectResults;
-   }
+    /**
+     * Hidden constructor. Only {@link BValidatorBuilderImpl} can create a {@link BValidator}.
+     */
+    BValidator(Set<BusinessRuleObject<T>> rules, Set<BusinessMemberObject<T,?>> members, String businessObjectName) {
+        this.businessObjectName = businessObjectName;
+        if((rules == null || rules.isEmpty()) && (members == null || members.isEmpty()) ){
+            throw new IllegalBusinessObjectException("Rules or members must be provided for a business object: "+businessObjectName);
+        }
+        this.rules = rules;
+        this.members = members;
+    }
 
-   private boolean isCollection(Class<?> objectClass) {
-      return Collection.class.isAssignableFrom(objectClass);
-   }
+    /**
+     * Verify if an object of type T is valid by running business
+     * rules tests methods listed in {@link BValidator#rules} and by validating all members
+     * accessible from the {@link BValidator#members}.
+     * The validation will test all business rules and store the results in an
+     * {@link ObjectResult}.
+     *
+     * @param object business object to validate.
+     * @return an {@link ObjectResult} that hold all the business rule and member results.
+     * @throws InvocationException  if an exception is raised while invoking a
+     *                              {@link java.util.function.Predicate} or a {@link java.util.function.Function}.
+     *                              function. The original exception will be wrapped as cause.
+     * @throws IllegalBusinessObjectException if an error occurs while validating a member (Wrong return type,...)
+     * @throws NullPointerException if the given object is null.
+     */
 
-   private List<ObjectResult> validate(Collection<?> objects, String name) {
-      return validate(objects.toArray(), name);
-   }
+    public ObjectResult validate(final T object) {
+        return this.validate(object, businessObjectName);
+    }
 
-   private List<ObjectResult> validate(Object[] objects, String name) {
-      List<ObjectResult> results = new ArrayList<>();
-      int index = -1;
-      for (Object object : objects) {
-         if (object != null) {
-            results.add(validate(object, name + "[" + ++index + "]"));
-         }
-      }
-      return results;
-   }
 
-   private ObjectResult validate(final Object object, final String name) {
-      ObjectResult objectResult = new ObjectResult(name);
-      Class<?> clazz = assertBusinessObjectClass(object);
-      List<Method> businessRules = getBusinessRuleMethods(clazz);
-      List<Method> businessMembers = getBusinessMemberMethods(clazz);
-      if (!businessRules.isEmpty() || !businessMembers.isEmpty()) {
-         objectResult.addRuleResults(validateBusinessRules(object, businessRules));
-         objectResult.addMemberResults(validateBusinessMembers(object, businessMembers));
-      } else {
-         throw new IllegalBusinessObjectException(
-               "The class " + clazz.getCanonicalName() + " annotated with @BusinessObject does " +
-                     "not have any public  @BusinessRule nor any public @BusinessMember methods " +
-                     "to verify.");
-      }
-      return objectResult;
-   }
+    /**
+     * Verify if an array of objects is valid by running business
+     * rules tests methods listed in {@link BValidator#rules} and by validating all members
+     * accessible from the {@link BValidator#members}.
+     * The validation will test all business rules and store the results in an
+     * {@link ObjectResult}.
+     *
+     * @param collection collection of business objects to validate.
+     * @return an {@link ObjectResult} that hold all the business rule and member results.
+     * @throws InvocationException  if an exception is raised while invoking a
+     *                              {@link java.util.function.Predicate} or a {@link java.util.function.Function}.
+     *                              function. The original exception will be wrapped as cause.
+     * @throws IllegalBusinessObjectException if an error occurs while validating a member (Wrong return type,...)
+     * @throws NullPointerException if the given object is null.
+     */
+    public List<ObjectResult> validate(final Collection<T> collection) {
+        return this.validate(collection, businessObjectName);
+    }
 
-   /**
-    * Perform validation of methods marked with {@link BusinessRule}. It will also validate
-    * inherited {@link BusinessRule} methods.
-    *
-    * @param object        object to validate
-    * @param businessRules business rule methods to run.
-    */
-   private List<RuleResult> validateBusinessRules(Object object, List<Method> businessRules) {
-      List<RuleResult> RuleResults = new ArrayList<>();
-      for (Method businessRuleMethod : businessRules) {
-         try {
-            RuleResults.add(new RuleResult(
-                  getBusinessRuleId(businessRuleMethod),
-                  getBusinessRuleDescription(businessRuleMethod),
-                  (Boolean) businessRuleMethod.invoke(object)
-            ));
-         } catch (IllegalAccessException | IllegalArgumentException | ClassCastException e) {
-            throw new IllegalBusinessObjectException(String.format(
-                  "Method '%s' of class '%s' does not respect BusinessRule method format (should " +
-                        "be  public with no arguments and return a boolean value).",
-                  businessRuleMethod.getName(),
-                  object.getClass().getCanonicalName()), e);
-         } catch (InvocationTargetException e) {
-            throw new InvocationException(e.getCause());
-         }
-      }
-      return RuleResults;
-   }
+    /**
+     * Verify if a collections of type T is valid by running business
+     * rules tests methods listed in {@link BValidator#rules} and by validating all members
+     * accessible from the {@link BValidator#members}.
+     * The validation will test all business rules and store the results in an
+     * {@link ObjectResult}.
+     *
+     * @param array array of business objects to validate.
+     * @return an {@link ObjectResult} that hold all the business rule and member results.
+     * @throws InvocationException  if an exception is raised while invoking a
+     *                              {@link java.util.function.Predicate} or a {@link java.util.function.Function}.
+     *                              function. The original exception will be wrapped as cause.
+     * @throws IllegalBusinessObjectException if an error occurs while validating a member (Wrong return type,...)
+     * @throws NullPointerException if the given object is null.
+     */
+    public List<ObjectResult> validate(final T[] array) {
+        return this.validate(array, businessObjectName);
+    }
 
-   private List<ObjectResult> validateBusinessMembers(Object object, List<Method> businessMembers) {
-      List<ObjectResult> membersResults = new ArrayList<>();
-      for (Method businessMember : businessMembers) {
-         try {
-            Object member = businessMember.invoke(object);
-            if (member != null) {
-               //Recursive call
-               membersResults.addAll(validateAnyMember(member, getMemberName(businessMember)));
+    private <R> ObjectResult validate(T object, String name) {
+        if (object == null) {
+            throw new NullPointerException("The object to validate cannot be null");
+        }
+        final ObjectResult result = new ObjectResult(name);
+        List<RuleResult> ruleResults = validateBusinessRules(object);
+        List<ObjectResult> memberResults = this.<R>validateBusinessMembers(object);
+        result.addRuleResults(ruleResults);
+        result.addMemberResults(memberResults);
+        return result;
+    }
+
+    private <R> List<ObjectResult> validate(Collection<T> collection, String name) {
+        List<ObjectResult> results = new ArrayList<>();
+        int index = -1;
+        for (T object : collection) {
+            results.add(this.<R>validate(object, name + "[" + ++index + "]"));
+        }
+        return results;
+    }
+
+    private List<ObjectResult> validate(T[] array, String name) {
+        return validate(Arrays.asList(array), name);
+    }
+
+    private <R> ObjectResult validateMember(final R object, final BValidator<R> validator, final String memberName) {
+        return validator.validate(object, memberName);
+    }
+
+    private <R> List<ObjectResult> validateMemberCollection(final Collection<R> collection, final BValidator<R> validator, final String memberName) {
+        return validator.<R>validate(collection, memberName);
+    }
+
+    private <R> List<ObjectResult> validateMemberArray(final R[] array, final BValidator<R> validator, final String memberName) {
+        return validator.validate(array, memberName);
+    }
+
+
+    private List<RuleResult> validateBusinessRules(final T object) {
+        final List<RuleResult> results = new ArrayList<>();
+        for (final BusinessRuleObject<T> rule : rules) {
+            try {
+                results.add(new RuleResult(rule.getId(), rule.getDescription(), rule.apply(object)));
             }
-         } catch (IllegalAccessException | IllegalArgumentException e) {
-            throw new IllegalBusinessObjectException(
-                  "Method '" + businessMember.getName() + "' does not respect BusinessMember " +
-                        "method format (should be public with no arguments and return an object " +
-                        "value that is a BusinessObject or a group of BusinessObject).", e);
-         } catch (InvocationTargetException e) {
-            throw new InvocationException(e.getCause());
-         }
-      }
-      return membersResults;
-   }
+            catch (InvocationException e) {
+                throw new InvocationException(e.getCause());
+            }
+        }
+        return results;
+    }
 
-   private String getBusinessObjectName(Class<?> clazz) {
-      BusinessObject annotation = clazz.getAnnotation(BusinessObject.class);
-      return annotation == null || annotation.name().isEmpty() ? clazz.getSimpleName() :
-            annotation.name();
-   }
+    private <R> List<ObjectResult> validateBusinessMembers(final T object)  {
+        final List<ObjectResult> results = new ArrayList<>();
+        for (final BusinessMemberObject<T, ?> member : members) {
+            try {
+                final Object memberValue = getMemberValue(object, member);
+                results.addAll(validateAnyMember(memberValue, (BValidator<R>) member.getValidator(), member.getName()));
+            }
+            catch (IllegalArgumentException e) {
+                throw new IllegalBusinessObjectException(
+                        "Method '" + member.getName() + "' does not respect BusinessMember " +
+                                "method format (should be public with no arguments and return an object " +
+                                "value that is a BusinessObject or a group of BusinessObject).", e);
+            }
+            catch (ClassCastException e){
+                throw new IllegalBusinessObjectException("Wrong member type", e);
+            }
+            catch (final Throwable e) {
+                if(e.getCause() != null)
+                    throw new InvocationException(e.getCause());
+                throw new InvocationException(e);
+            }
+        }
+        return results;
+    }
 
-   private String getBusinessRuleDescription(Method businessRule) {
-      return businessRule.getAnnotation(BusinessRule.class).description();
-   }
+    private <R> void castGenericCheck(Object object) throws ClassCastException {
+           R casted = (R) object;
+    }
 
-   private String getBusinessRuleId(Method businessRule) {
-      return businessRule.getAnnotation(BusinessRule.class).id();
-   }
+    private Object getMemberValue(final T object, final BusinessMemberObject<T, ?> member) throws Throwable{
+        try {
+            return member.getMemberValue(object);
+        }
+        catch (final InvocationException e) {
+            throw e.getCause();
+        }
+    }
 
-   private String getMemberName(Method businessMember) {
-      BusinessMember annotation = businessMember.getAnnotation(BusinessMember.class);
-      return annotation.name().isEmpty() ? businessMember.getName() : annotation.name();
-   }
+    private <R> List<ObjectResult>  validateAnyMember(final Object memberValue, BValidator<R> validator, String name) {
+        final List<ObjectResult> results = new ArrayList<>();
+        if(memberValue == null){
+            return Collections.emptyList();
+        }
+        if (isValidCollection(memberValue)) {
+            this.<R>castGenericCheck(((Collection<?>) memberValue).iterator().next());
+            results.addAll(this.validateMemberCollection((Collection<R>) memberValue, validator, name));
+        } else if (isValidArray(memberValue)) {
+            this.<R>castGenericCheck(((Object[]) memberValue)[0]);
+            results.addAll(this.validateMemberArray((R[]) memberValue, validator, name));
+        } else {
+            this.<R>castGenericCheck(memberValue);
+            results.add(this.validateMember((R)memberValue, validator, name));
+        }
+        return results;
+    }
 
-   private List<Method> getBusinessRuleMethods(Class<?> clazz) {
-      return getAnnotatedPublicMethod(clazz, BusinessRule.class);
-   }
+    private boolean isValidCollection(Object memberValue) {
+        return (memberValue instanceof Collection) && !((Collection<?>) memberValue).isEmpty();
+    }
 
-   private List<Method> getBusinessMemberMethods(Class<?> clazz) {
-      return getAnnotatedPublicMethod(clazz, BusinessMember.class);
-   }
+    private boolean isValidArray(Object memberValue) {
+        return (memberValue instanceof Object[]) && ((Object[]) memberValue).length > 0;
+    }
 
-   private List<Method> getAnnotatedPublicMethod(Class<?> clazz,
-                                                 Class<? extends Annotation> annotation) {
-      List<Method> annotatedPublicMethods = new ArrayList<>();
-      for (Method method : clazz.getMethods()) {
-         if (method.isAnnotationPresent(annotation) && method.getModifiers() == Modifier.PUBLIC) {
-            annotatedPublicMethods.add(method);
-         }
-      }
-      return annotatedPublicMethods;
-   }
 
-   private Class<?> assertBusinessObjectClass(Object object) {
-      Class<?> clazz = object.getClass();
-      if (isBusinessObject(clazz) || hasASuperClassBusinessObject(clazz.getSuperclass())) {
-         return clazz;
-      } else {
-         throw new IllegalBusinessObjectException("The object's class " + clazz.getCanonicalName()
-               + " is not annotated with @BusinessObject.");
-      }
-   }
 
-   private boolean isBusinessObject(Class<?> clazz) {
-      return clazz.isAnnotationPresent(BusinessObject.class);
-   }
 
-   private boolean hasASuperClassBusinessObject(Class<?> superClass) {
-      if (isOnTopClassHierarchy(superClass)) {
-         return false;
-      } else {
-         if (isBusinessObject(superClass)) {
-            return true;
-         } else {
-            return hasASuperClassBusinessObject(superClass.getSuperclass());
-         }
-      }
-   }
-
-   private boolean isOnTopClassHierarchy(Class<?> superClass) {
-      return superClass.equals(Object.class);
-   }
 }

--- a/src/main/java/io/github/ceoche/bvalid/BValidatorAnnotationBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidatorAnnotationBuilder.java
@@ -36,6 +36,7 @@ public class BValidatorAnnotationBuilder<T> extends AbstractBValidatorBuilder<T>
     }
 
     public BValidatorAnnotationBuilder(Class<T> clazz) {
+        super(clazz);
         BusinessObject businessObject = clazz.getAnnotation(BusinessObject.class);
         if (businessObject != null) {
             businessObjectName = businessObject.name();
@@ -56,17 +57,13 @@ public class BValidatorAnnotationBuilder<T> extends AbstractBValidatorBuilder<T>
 
     @Override
     public BValidator<T> build(){
-        return new BValidatorManualBuilder<T>()
+        return new BValidatorManualBuilder<T>(type)
                 .addAllMembers(members)
                 .addAllRules(rules)
                 .setBusinessObjectName(businessObjectName)
                 .build();
     }
 
-    @Override
-    public boolean isEmpty() {
-        return rules.isEmpty() && members.isEmpty();
-    }
 
 
 
@@ -180,6 +177,7 @@ public class BValidatorAnnotationBuilder<T> extends AbstractBValidatorBuilder<T>
     private boolean isOnTopClassHierarchy(Class<?> superClass) {
         return superClass.equals(Object.class);
     }
+
 
 
 }

--- a/src/main/java/io/github/ceoche/bvalid/BValidatorAnnotationBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidatorAnnotationBuilder.java
@@ -1,9 +1,7 @@
 package io.github.ceoche.bvalid;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -14,13 +12,28 @@ import java.util.function.Predicate;
  * @param <T>
  * @author a.achkari
  */
-public class BValidatorAnnotationBuilder<T> implements BValidatorBuilder<T> {
+public class BValidatorAnnotationBuilder<T> extends AbstractBValidatorBuilder<T> {
 
-    private final List<BusinessRuleObject<T>> rules;
+    private final Set<BusinessRuleObject<T>> rules;
 
-    private final List<BusinessMemberBuilder<T,?>> members;
+    private final Set<BusinessMemberBuilder<T,?>> members;
 
     private String businessObjectName = "";
+
+    @Override
+    public Set<BusinessRuleObject<T>> getRules() {
+        return rules;
+    }
+
+    @Override
+    public Set<BusinessMemberBuilder<T, ?>> getMembers() {
+        return members;
+    }
+
+    @Override
+    public String getBusinessObjectName() {
+        return businessObjectName;
+    }
 
     public BValidatorAnnotationBuilder(Class<T> clazz) {
         BusinessObject businessObject = clazz.getAnnotation(BusinessObject.class);
@@ -55,8 +68,10 @@ public class BValidatorAnnotationBuilder<T> implements BValidatorBuilder<T> {
         return rules.isEmpty() && members.isEmpty();
     }
 
-    private List<BusinessRuleObject<T>> getRules(Class<T> clazz) {
-        List<BusinessRuleObject<T>> rulesResult = new ArrayList<>();
+
+
+    private Set<BusinessRuleObject<T>> getRules(Class<T> clazz) {
+        Set<BusinessRuleObject<T>> rulesResult = new LinkedHashSet<>();
         for (Method method : clazz.getMethods()) {
             if(method.isAnnotationPresent(BusinessRule.class)){
                 BusinessRule businessRule = method.getAnnotation(BusinessRule.class);
@@ -70,8 +85,8 @@ public class BValidatorAnnotationBuilder<T> implements BValidatorBuilder<T> {
         return rulesResult;
     }
 
-    private List<BusinessMemberBuilder<T,?>> getMembers(Class<T> clazz) {
-        List<BusinessMemberBuilder<T,?>> memberBuilderList = new ArrayList<>();
+    private Set<BusinessMemberBuilder<T,?>> getMembers(Class<T> clazz) {
+        Set<BusinessMemberBuilder<T,?>> memberBuilderList = new LinkedHashSet<>();
         for (Method method : clazz.getMethods()) {
             if(method.isAnnotationPresent(BusinessMember.class)){
                 BusinessMember businessMember = method.getAnnotation(BusinessMember.class);

--- a/src/main/java/io/github/ceoche/bvalid/BValidatorAnnotationBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidatorAnnotationBuilder.java
@@ -9,7 +9,7 @@ import java.util.function.Predicate;
 
 /**
  * Build a {@link BValidator} from a {@link BusinessObject} annotated class
- * using the {@link BValidatorBuilderImpl}.
+ * using the {@link BValidatorManualBuilder}.
  *
  * @param <T>
  * @author a.achkari
@@ -43,7 +43,7 @@ public class BValidatorAnnotationBuilder<T> implements BValidatorBuilder<T> {
 
     @Override
     public BValidator<T> build(){
-        return new BValidatorBuilderImpl<T>()
+        return new BValidatorManualBuilder<T>()
                 .addAllMembers(members)
                 .addAllRules(rules)
                 .setBusinessObjectName(businessObjectName)

--- a/src/main/java/io/github/ceoche/bvalid/BValidatorAnnotationBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidatorAnnotationBuilder.java
@@ -1,0 +1,170 @@
+package io.github.ceoche.bvalid;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Build a {@link BValidator} from a {@link BusinessObject} annotated class
+ * using the {@link BValidatorBuilderImpl}.
+ *
+ * @param <T>
+ * @author a.achkari
+ */
+public class BValidatorAnnotationBuilder<T> implements BValidatorBuilder<T> {
+
+    private final List<BusinessRuleObject<T>> rules;
+
+    private final List<BusinessMemberBuilder<T,?>> members;
+
+    private String businessObjectName = "";
+
+    public BValidatorAnnotationBuilder(Class<T> clazz) {
+        BusinessObject businessObject = clazz.getAnnotation(BusinessObject.class);
+        if (businessObject != null) {
+            businessObjectName = businessObject.name();
+            if(businessObjectName.isEmpty()) {
+                businessObjectName = clazz.getSimpleName();
+            }
+        }
+        Class<T> assertedClass = (Class<T>) assertBusinessObjectClass(clazz);
+        this.rules = getRules(assertedClass);
+        this.members = getMembers(assertedClass);
+    }
+
+
+    public BValidatorAnnotationBuilder<T> setBusinessObjectName(String businessObjectName){
+        this.businessObjectName = businessObjectName;
+        return this;
+    }
+
+    @Override
+    public BValidator<T> build(){
+        return new BValidatorBuilderImpl<T>()
+                .addAllMembers(members)
+                .addAllRules(rules)
+                .setBusinessObjectName(businessObjectName)
+                .build();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return rules.isEmpty() && members.isEmpty();
+    }
+
+    private List<BusinessRuleObject<T>> getRules(Class<T> clazz) {
+        List<BusinessRuleObject<T>> rulesResult = new ArrayList<>();
+        for (Method method : clazz.getMethods()) {
+            if(method.isAnnotationPresent(BusinessRule.class)){
+                BusinessRule businessRule = method.getAnnotation(BusinessRule.class);
+                String id = businessRule.id();
+                if(id.isEmpty() || id.isBlank()){
+                    id = getRuleIdFromMethodName(method.getName());
+                }
+                rulesResult.add(new BusinessRuleObject<>(id, getPredicate(method), businessRule.description()));
+            }
+        }
+        return rulesResult;
+    }
+
+    private List<BusinessMemberBuilder<T,?>> getMembers(Class<T> clazz) {
+        List<BusinessMemberBuilder<T,?>> memberBuilderList = new ArrayList<>();
+        for (Method method : clazz.getMethods()) {
+            if(method.isAnnotationPresent(BusinessMember.class)){
+                BusinessMember businessMember = method.getAnnotation(BusinessMember.class);
+                memberBuilderList.add(new BusinessMemberBuilder<>(businessMember.name(), getFunction(method), getValidatorBuilderSupplier(method)));
+            }
+        }
+        return memberBuilderList;
+    }
+
+    private Predicate<T> getPredicate(Method method) throws InvocationException {
+        return object -> {
+            try {
+                return (boolean) method.invoke(object);
+            } catch (Exception e) {
+                throw new InvocationException(e.getCause());
+            }
+        };
+    }
+
+    private Function<T, ?> getFunction(Method method) throws InvocationException {
+        return object -> {
+            try {
+                return method.invoke(object);
+            } catch (Exception e) {
+                throw new InvocationException(e);
+            }
+        };
+    }
+
+    private BValidatorBuilder<?> getValidatorBuilderSupplier(Method method) throws InvocationException {
+        Class<?> clazz = getRealType(method);
+        return new BValidatorAnnotationBuilder<>(clazz);
+    }
+
+    private Class<?> getRealType(Method method) {
+        Class<?> clazz = method.getReturnType();
+        if (clazz.isArray()) {
+            return clazz.getComponentType();
+        } else if (Collection.class.isAssignableFrom(clazz)) {
+            return getGenericTypeParameter(method);
+        } else {
+            return clazz;
+        }
+    }
+
+    private String getRuleIdFromMethodName(String methodName){
+        return methodName.replace("is", "");
+    }
+
+
+    private Class<?> getGenericTypeParameter(Method method) {
+        String genericType = method.getGenericReturnType().getTypeName();
+        if(genericType.contains("<") && genericType.contains(">")){
+            String className = genericType.substring(genericType.indexOf("<") + 1, genericType.indexOf(">"));
+            try {
+                return Class.forName(className);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        throw new RuntimeException("Cannot find generic type for method " + method.getName());
+    }
+
+
+
+    private Class<?> assertBusinessObjectClass(Class<?> clazz) {
+        if (!Object.class.equals(clazz) && (isBusinessObject(clazz) || hasASuperClassBusinessObject(clazz.getSuperclass()))) {
+            return clazz;
+        } else {
+            throw new IllegalBusinessObjectException("The object's class " + clazz.getCanonicalName()
+                    + " is not annotated with @BusinessObject.");
+        }
+    }
+
+    private boolean isBusinessObject(Class<?> clazz) {
+        return clazz.isAnnotationPresent(BusinessObject.class);
+    }
+
+    private boolean hasASuperClassBusinessObject(Class<?> superClass) {
+        if (superClass == null || isOnTopClassHierarchy(superClass)) {
+            return false;
+        } else {
+            if (isBusinessObject(superClass)) {
+                return true;
+            } else {
+                return hasASuperClassBusinessObject(superClass.getSuperclass());
+            }
+        }
+    }
+
+    private boolean isOnTopClassHierarchy(Class<?> superClass) {
+        return superClass.equals(Object.class);
+    }
+
+
+}

--- a/src/main/java/io/github/ceoche/bvalid/BValidatorAnnotationBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidatorAnnotationBuilder.java
@@ -12,7 +12,7 @@ import java.util.function.Predicate;
  * using the {@link BValidatorManualBuilder}.
  *
  * @param <T>
- * @author a.achkari
+ * @author Achraf Achkari
  */
 public class BValidatorAnnotationBuilder<T> extends AbstractBValidatorBuilder<T> {
 

--- a/src/main/java/io/github/ceoche/bvalid/BValidatorAnnotationBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidatorAnnotationBuilder.java
@@ -1,7 +1,9 @@
 package io.github.ceoche.bvalid;
 
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -26,7 +28,7 @@ public class BValidatorAnnotationBuilder<T> extends AbstractBValidatorBuilder<T>
     }
 
     @Override
-    public Set<BusinessMemberBuilder<T, ?>> getMembers() {
+    Set<BusinessMemberBuilder<T, ?>> getMembers() {
         return members;
     }
 

--- a/src/main/java/io/github/ceoche/bvalid/BValidatorBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidatorBuilder.java
@@ -1,8 +1,12 @@
 package io.github.ceoche.bvalid;
 
+import java.util.Set;
+
 public interface BValidatorBuilder <T> {
 
     BValidator<T> build();
 
     boolean isEmpty();
+
+    Set<BusinessMemberBuilder<T,?>> getMembers();
 }

--- a/src/main/java/io/github/ceoche/bvalid/BValidatorBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidatorBuilder.java
@@ -1,5 +1,12 @@
 package io.github.ceoche.bvalid;
 
+
+/**
+ * The API to build a {@link BValidator}.
+ * @param <T> the type of the business object to validate
+ *
+ * @author Achraf Achkari
+ */
 public interface BValidatorBuilder <T> {
 
     /**

--- a/src/main/java/io/github/ceoche/bvalid/BValidatorBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidatorBuilder.java
@@ -1,0 +1,8 @@
+package io.github.ceoche.bvalid;
+
+public interface BValidatorBuilder <T> {
+
+    BValidator<T> build();
+
+    boolean isEmpty();
+}

--- a/src/main/java/io/github/ceoche/bvalid/BValidatorBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidatorBuilder.java
@@ -1,12 +1,19 @@
 package io.github.ceoche.bvalid;
 
-import java.util.Set;
-
 public interface BValidatorBuilder <T> {
 
+    /**
+     * Build the {@link BValidator} from the builder.
+     * @return the {@link BValidator} built
+     * @throws IllegalStateException if the type of the business object is not set
+     * @throws IllegalBusinessObjectException if the builder is empty (i.e. no rules or members)
+     */
     BValidator<T> build();
 
+    /**
+     * Check if the builder is empty (i.e. no rules or members).
+     * @return true if the builder is empty, false otherwise
+     */
     boolean isEmpty();
 
-    Set<BusinessMemberBuilder<T,?>> getMembers();
 }

--- a/src/main/java/io/github/ceoche/bvalid/BValidatorBuilderImpl.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidatorBuilderImpl.java
@@ -1,0 +1,71 @@
+package io.github.ceoche.bvalid;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class BValidatorBuilderImpl<T> implements BValidatorBuilder<T> {
+
+    private final Set<BusinessRuleObject<T>> rules = new HashSet<>();
+
+    private final Set<BusinessMemberBuilder<T,?>> members = new HashSet<>();
+
+
+    private String businessObjectName = "";
+
+    public BValidatorBuilderImpl<T> addRule(String id, Predicate<T> rule, String description){
+        if(id == null || rule == null){
+            throw new IllegalArgumentException("Id and rule must not be null");
+        }
+        rules.add(new BusinessRuleObject<>(id, rule, description));
+        return this;
+    }
+
+    public <R> BValidatorBuilderImpl<T> addMember(String name, Function<T, ?> getter, BValidatorBuilder<R> bValidatorBuilder){
+        if(name == null || getter == null || bValidatorBuilder == null){
+            throw new IllegalArgumentException("Name, getter and bValidatorBuilder must not be null");
+        }
+        members.add(new BusinessMemberBuilder<>(name, getter, bValidatorBuilder));
+        return this;
+    }
+
+    public BValidatorBuilderImpl<T> addAllMembers(Collection<BusinessMemberBuilder<T,?>> members){
+        this.members.addAll(members);
+        return this;
+    }
+
+    public BValidatorBuilderImpl<T> addAllRules(Collection<BusinessRuleObject<T>> rules){
+        this.rules.addAll(rules);
+        return this;
+    }
+
+    public BValidatorBuilderImpl<T> setBusinessObjectName(String businessObjectName){
+        this.businessObjectName = businessObjectName;
+        return this;
+    }
+
+    public int getRulesCount(){
+        return rules.size();
+    }
+
+    public int getMembersCount(){
+        return members.size();
+    }
+
+    @Override
+    public BValidator<T> build(){
+        Set<BusinessMemberObject<T,?>> businessMemberObjects = new HashSet<>();
+        for (BusinessMemberBuilder<T,?> businessMemberBuilder : members) {
+            if(!businessMemberBuilder.getValidatorBuilder().isEmpty()){
+                businessMemberObjects.add(new BusinessMemberObject<>(businessMemberBuilder.getName(),
+                        businessMemberBuilder.getGetter(), businessMemberBuilder.getValidatorBuilder().build()));
+            }
+        }
+        return new BValidator<>(rules, businessMemberObjects, businessObjectName);
+    }
+
+   @Override
+   public boolean isEmpty() {
+        return rules.isEmpty() && members.isEmpty();
+    }
+}

--- a/src/main/java/io/github/ceoche/bvalid/BValidatorManualBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidatorManualBuilder.java
@@ -12,11 +12,21 @@ public class BValidatorManualBuilder<T> extends AbstractBValidatorBuilder<T> {
 
     private final Set<Class<?>> implementations = new HashSet<>();
 
+//    private final BValidatorBuilder<? extends R>[] validatorBuilder;
+
     private String businessObjectName = "";
 
     public BValidatorManualBuilder(Class<T> type){
         super(type);
     }
+
+    public BValidatorManualBuilder(BValidatorManualBuilder<? super T> builder, Class<T> type){
+        super(type);
+        builder.rules.forEach(rule -> rules.add((BusinessRuleObject<T>) rule));
+        builder.members.forEach(member -> members.add((BusinessMemberBuilder<T, ?>) member));
+        implementations.addAll(builder.implementations);
+    }
+
 
     @Override
     public Set<BusinessRuleObject<T>> getRules() {

--- a/src/main/java/io/github/ceoche/bvalid/BValidatorManualBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidatorManualBuilder.java
@@ -10,7 +10,13 @@ public class BValidatorManualBuilder<T> extends AbstractBValidatorBuilder<T> {
 
     private final Set<BusinessMemberBuilder<T,?>> members = new LinkedHashSet<>();
 
+    private final Set<Class<?>> implementations = new HashSet<>();
+
     private String businessObjectName = "";
+
+    public BValidatorManualBuilder(Class<T> type){
+        super(type);
+    }
 
     @Override
     public Set<BusinessRuleObject<T>> getRules() {
@@ -35,11 +41,12 @@ public class BValidatorManualBuilder<T> extends AbstractBValidatorBuilder<T> {
         return this;
     }
 
-    public <R> BValidatorManualBuilder<T> addMember(String name, Function<T, ?> getter, BValidatorBuilder<R> bValidatorBuilder){
-        if(name == null || getter == null || bValidatorBuilder == null){
-            throw new IllegalArgumentException("Name, getter and bValidatorBuilder must not be null");
+    @SafeVarargs
+    public final <R> BValidatorManualBuilder<T> addMember(String name, Function<T, ?> getter, BValidatorBuilder<? extends R>... bValidatorBuilders){
+        if(name == null || getter == null || isThereNullBuilder(bValidatorBuilders)){
+            throw new IllegalArgumentException("Name, getter and bValidatorBuilders must not be null");
         }
-        members.add(new BusinessMemberBuilder<>(name, getter, bValidatorBuilder));
+        members.add(new BusinessMemberBuilder<>(name, getter, bValidatorBuilders));
         return this;
     }
 
@@ -73,13 +80,13 @@ public class BValidatorManualBuilder<T> extends AbstractBValidatorBuilder<T> {
     }
 
 
-
-   @Override
-   public boolean isEmpty() {
-        return rules.isEmpty() && members.isEmpty();
+    private boolean isThereNullBuilder(BValidatorBuilder<?>... bValidatorBuilders){
+        for (BValidatorBuilder<?> bValidatorBuilder : bValidatorBuilders) {
+            if(bValidatorBuilder == null){
+                return true;
+            }
+        }
+        return false;
     }
-
-
-
 
 }

--- a/src/main/java/io/github/ceoche/bvalid/BValidatorManualBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidatorManualBuilder.java
@@ -4,14 +4,28 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-public class BValidatorManualBuilder<T> implements BValidatorBuilder<T> {
+public class BValidatorManualBuilder<T> extends AbstractBValidatorBuilder<T> {
 
-    private final Set<BusinessRuleObject<T>> rules = new HashSet<>();
+    private final Set<BusinessRuleObject<T>> rules = new LinkedHashSet<>();
 
-    private final Set<BusinessMemberBuilder<T,?>> members = new HashSet<>();
-
+    private final Set<BusinessMemberBuilder<T,?>> members = new LinkedHashSet<>();
 
     private String businessObjectName = "";
+
+    @Override
+    public Set<BusinessRuleObject<T>> getRules() {
+        return rules;
+    }
+
+    @Override
+    public Set<BusinessMemberBuilder<T, ?>> getMembers() {
+        return members;
+    }
+
+    @Override
+    public String getBusinessObjectName() {
+        return businessObjectName;
+    }
 
     public BValidatorManualBuilder<T> addRule(String id, Predicate<T> rule, String description){
         if(id == null || rule == null){
@@ -29,12 +43,12 @@ public class BValidatorManualBuilder<T> implements BValidatorBuilder<T> {
         return this;
     }
 
-    public BValidatorManualBuilder<T> addAllMembers(Collection<BusinessMemberBuilder<T,?>> members){
+    public BValidatorManualBuilder<T> addAllMembers(Set<BusinessMemberBuilder<T, ?>> members){
         this.members.addAll(members);
         return this;
     }
 
-    public BValidatorManualBuilder<T> addAllRules(Collection<BusinessRuleObject<T>> rules){
+    public BValidatorManualBuilder<T> addAllRules(Set<BusinessRuleObject<T>> rules){
         this.rules.addAll(rules);
         return this;
     }
@@ -54,18 +68,18 @@ public class BValidatorManualBuilder<T> implements BValidatorBuilder<T> {
 
     @Override
     public BValidator<T> build(){
-        Set<BusinessMemberObject<T,?>> businessMemberObjects = new HashSet<>();
-        for (BusinessMemberBuilder<T,?> businessMemberBuilder : members) {
-            if(!businessMemberBuilder.getValidatorBuilder().isEmpty()){
-                businessMemberObjects.add(new BusinessMemberObject<>(businessMemberBuilder.getName(),
-                        businessMemberBuilder.getGetter(), businessMemberBuilder.getValidatorBuilder().build()));
-            }
-        }
-        return new BValidator<>(rules, businessMemberObjects, businessObjectName);
+        Map<AbstractBValidatorBuilder<?>,BValidator<?>> visitedBuilders = new HashMap<>();
+        return build(visitedBuilders);
     }
+
+
 
    @Override
    public boolean isEmpty() {
         return rules.isEmpty() && members.isEmpty();
     }
+
+
+
+
 }

--- a/src/main/java/io/github/ceoche/bvalid/BValidatorManualBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidatorManualBuilder.java
@@ -4,7 +4,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-public class BValidatorBuilderImpl<T> implements BValidatorBuilder<T> {
+public class BValidatorManualBuilder<T> implements BValidatorBuilder<T> {
 
     private final Set<BusinessRuleObject<T>> rules = new HashSet<>();
 
@@ -13,7 +13,7 @@ public class BValidatorBuilderImpl<T> implements BValidatorBuilder<T> {
 
     private String businessObjectName = "";
 
-    public BValidatorBuilderImpl<T> addRule(String id, Predicate<T> rule, String description){
+    public BValidatorManualBuilder<T> addRule(String id, Predicate<T> rule, String description){
         if(id == null || rule == null){
             throw new IllegalArgumentException("Id and rule must not be null");
         }
@@ -21,7 +21,7 @@ public class BValidatorBuilderImpl<T> implements BValidatorBuilder<T> {
         return this;
     }
 
-    public <R> BValidatorBuilderImpl<T> addMember(String name, Function<T, ?> getter, BValidatorBuilder<R> bValidatorBuilder){
+    public <R> BValidatorManualBuilder<T> addMember(String name, Function<T, ?> getter, BValidatorBuilder<R> bValidatorBuilder){
         if(name == null || getter == null || bValidatorBuilder == null){
             throw new IllegalArgumentException("Name, getter and bValidatorBuilder must not be null");
         }
@@ -29,17 +29,17 @@ public class BValidatorBuilderImpl<T> implements BValidatorBuilder<T> {
         return this;
     }
 
-    public BValidatorBuilderImpl<T> addAllMembers(Collection<BusinessMemberBuilder<T,?>> members){
+    public BValidatorManualBuilder<T> addAllMembers(Collection<BusinessMemberBuilder<T,?>> members){
         this.members.addAll(members);
         return this;
     }
 
-    public BValidatorBuilderImpl<T> addAllRules(Collection<BusinessRuleObject<T>> rules){
+    public BValidatorManualBuilder<T> addAllRules(Collection<BusinessRuleObject<T>> rules){
         this.rules.addAll(rules);
         return this;
     }
 
-    public BValidatorBuilderImpl<T> setBusinessObjectName(String businessObjectName){
+    public BValidatorManualBuilder<T> setBusinessObjectName(String businessObjectName){
         this.businessObjectName = businessObjectName;
         return this;
     }

--- a/src/main/java/io/github/ceoche/bvalid/BValidatorManualBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BValidatorManualBuilder.java
@@ -1,18 +1,23 @@
 package io.github.ceoche.bvalid;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+
+/**
+ * Build a {@link BValidator} programmatically using the {@link BValidatorManualBuilder}.
+ * @param <T> the type of the business object to validate
+ */
 public class BValidatorManualBuilder<T> extends AbstractBValidatorBuilder<T> {
 
     private final Set<BusinessRuleObject<T>> rules = new LinkedHashSet<>();
 
     private final Set<BusinessMemberBuilder<T,?>> members = new LinkedHashSet<>();
 
-    private final Set<Class<?>> implementations = new HashSet<>();
-
-//    private final BValidatorBuilder<? extends R>[] validatorBuilder;
 
     private String businessObjectName = "";
 
@@ -24,7 +29,6 @@ public class BValidatorManualBuilder<T> extends AbstractBValidatorBuilder<T> {
         super(type);
         builder.rules.forEach(rule -> rules.add((BusinessRuleObject<T>) rule));
         builder.members.forEach(member -> members.add((BusinessMemberBuilder<T, ?>) member));
-        implementations.addAll(builder.implementations);
     }
 
 
@@ -34,7 +38,7 @@ public class BValidatorManualBuilder<T> extends AbstractBValidatorBuilder<T> {
     }
 
     @Override
-    public Set<BusinessMemberBuilder<T, ?>> getMembers() {
+    Set<BusinessMemberBuilder<T, ?>> getMembers() {
         return members;
     }
 
@@ -43,14 +47,44 @@ public class BValidatorManualBuilder<T> extends AbstractBValidatorBuilder<T> {
         return businessObjectName;
     }
 
+    /**
+     * Add a rule in form of Java Predicate {@link Predicate<T>} to the validator.
+     * @param id the specification id of the rule
+     * @param rule the rule to add
+     * @param description the description of the rule
+     * @return the builder
+     * @throws IllegalArgumentException if the rule is null
+     */
     public BValidatorManualBuilder<T> addRule(String id, Predicate<T> rule, String description){
-        if(id == null || rule == null){
+        if(rule == null){
             throw new IllegalArgumentException("Id and rule must not be null");
         }
         rules.add(new BusinessRuleObject<>(id, rule, description));
         return this;
     }
 
+    /**
+     * Add a rule in form of Java Predicate {@link Predicate<T>} to the validator.
+     * @param rule the rule to add
+     * @param description the description of the rule
+     * @return the builder
+     * @throws IllegalArgumentException if the rule is null
+     */
+    public BValidatorManualBuilder<T> addRule(Predicate<T> rule, String description){
+        addRule("", rule, description);
+        return this;
+    }
+
+
+    /**
+     * Add a member to the validator.
+     * @param name the name of the field
+     * @param getter the getter of the field in form of a Java Function {@link Function}
+     * @param bValidatorBuilders All the validators builders of the possible subtypes of the field
+     * @return the builder
+     * @param <R> the type of the field
+     * @throws IllegalArgumentException if the name, getter or bValidatorBuilders are null
+     */
     @SafeVarargs
     public final <R> BValidatorManualBuilder<T> addMember(String name, Function<T, ?> getter, BValidatorBuilder<? extends R>... bValidatorBuilders){
         if(name == null || getter == null || isThereNullBuilder(bValidatorBuilders)){
@@ -60,7 +94,8 @@ public class BValidatorManualBuilder<T> extends AbstractBValidatorBuilder<T> {
         return this;
     }
 
-    public BValidatorManualBuilder<T> addAllMembers(Set<BusinessMemberBuilder<T, ?>> members){
+
+    BValidatorManualBuilder<T> addAllMembers(Set<BusinessMemberBuilder<T, ?>> members){
         this.members.addAll(members);
         return this;
     }

--- a/src/main/java/io/github/ceoche/bvalid/BusinessMemberBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BusinessMemberBuilder.java
@@ -10,6 +10,7 @@ public class BusinessMemberBuilder <T,R>{
 
     private final BValidatorBuilder<R> validatorBuilder;
 
+
     public BusinessMemberBuilder(String name, Function<T, ?> getter, BValidatorBuilder<R> bValidatorBuilder) {
         this.name = name;
         this.getter = getter;
@@ -27,5 +28,6 @@ public class BusinessMemberBuilder <T,R>{
     public BValidatorBuilder<R> getValidatorBuilder() {
         return validatorBuilder;
     }
+
 
 }

--- a/src/main/java/io/github/ceoche/bvalid/BusinessMemberBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BusinessMemberBuilder.java
@@ -1,0 +1,31 @@
+package io.github.ceoche.bvalid;
+
+import java.util.function.Function;
+
+public class BusinessMemberBuilder <T,R>{
+
+    private final String name;
+
+    private final Function<T, ?> getter;
+
+    private final BValidatorBuilder<R> validatorBuilder;
+
+    public BusinessMemberBuilder(String name, Function<T, ?> getter, BValidatorBuilder<R> bValidatorBuilder) {
+        this.name = name;
+        this.getter = getter;
+        this.validatorBuilder = bValidatorBuilder;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Function<T, ?> getGetter() {
+        return getter;
+    }
+
+    public BValidatorBuilder<R> getValidatorBuilder() {
+        return validatorBuilder;
+    }
+
+}

--- a/src/main/java/io/github/ceoche/bvalid/BusinessMemberBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BusinessMemberBuilder.java
@@ -8,10 +8,11 @@ public class BusinessMemberBuilder <T,R>{
 
     private final Function<T, ?> getter;
 
-    private final BValidatorBuilder<R> validatorBuilder;
+    private final BValidatorBuilder<? extends R>[] validatorBuilder;
 
 
-    public BusinessMemberBuilder(String name, Function<T, ?> getter, BValidatorBuilder<R> bValidatorBuilder) {
+    @SafeVarargs
+    public BusinessMemberBuilder(String name, Function<T, ?> getter, BValidatorBuilder<? extends R> ...bValidatorBuilder) {
         this.name = name;
         this.getter = getter;
         this.validatorBuilder = bValidatorBuilder;
@@ -25,7 +26,7 @@ public class BusinessMemberBuilder <T,R>{
         return getter;
     }
 
-    public BValidatorBuilder<R> getValidatorBuilder() {
+    public BValidatorBuilder<? extends R>[] getValidatorBuilders() {
         return validatorBuilder;
     }
 

--- a/src/main/java/io/github/ceoche/bvalid/BusinessMemberBuilder.java
+++ b/src/main/java/io/github/ceoche/bvalid/BusinessMemberBuilder.java
@@ -2,7 +2,13 @@ package io.github.ceoche.bvalid;
 
 import java.util.function.Function;
 
-public class BusinessMemberBuilder <T,R>{
+/**
+ * Utility class to hold builders of a member at runtime.
+ * Class not intended to be used outside the library.
+ * @param <T> the type of the business object to validate
+ * @param <R> the type of the member to validate
+ */
+class BusinessMemberBuilder <T,R>{
 
     private final String name;
 
@@ -12,7 +18,7 @@ public class BusinessMemberBuilder <T,R>{
 
 
     @SafeVarargs
-    public BusinessMemberBuilder(String name, Function<T, ?> getter, BValidatorBuilder<? extends R> ...bValidatorBuilder) {
+    BusinessMemberBuilder(String name, Function<T, ?> getter, BValidatorBuilder<? extends R> ...bValidatorBuilder) {
         this.name = name;
         this.getter = getter;
         this.validatorBuilder = bValidatorBuilder;

--- a/src/main/java/io/github/ceoche/bvalid/BusinessMemberObject.java
+++ b/src/main/java/io/github/ceoche/bvalid/BusinessMemberObject.java
@@ -1,5 +1,6 @@
 package io.github.ceoche.bvalid;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -9,12 +10,12 @@ public class BusinessMemberObject<T,R> {
 
     private final Function<T, ?> getter;
 
-    private final BValidator<R> validator;
+    private final Map<Class<?>,BValidator<? extends R>> validators;
 
-    public BusinessMemberObject(String name, Function<T, ?> getter, BValidator<R> validator) {
+    public BusinessMemberObject(String name, Function<T, ?> getter, Map<Class<?>,BValidator<? extends R>> validators) {
         this.name = name;
         this.getter = getter;
-        this.validator = validator;
+        this.validators = validators;
     }
 
     public String getName() {
@@ -25,8 +26,13 @@ public class BusinessMemberObject<T,R> {
         return getter.apply(object);
     }
 
-    public  BValidator<R> getValidator() {
-        return validator;
+    public void addValidator(Class<?> clazz, BValidator<?> validator) {
+        this.validators.put(clazz, (BValidator<? extends R>) validator);
+
+    }
+
+    public Map<Class<?>, BValidator<? extends R>> getValidators() {
+        return validators;
     }
 
     @Override

--- a/src/main/java/io/github/ceoche/bvalid/BusinessMemberObject.java
+++ b/src/main/java/io/github/ceoche/bvalid/BusinessMemberObject.java
@@ -1,0 +1,44 @@
+package io.github.ceoche.bvalid;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+public class BusinessMemberObject<T,R> {
+
+    private final String name;
+
+    private final Function<T, ?> getter;
+
+    private final BValidator<R> validator;
+
+    public BusinessMemberObject(String name, Function<T, ?> getter, BValidator<R> validator) {
+        this.name = name;
+        this.getter = getter;
+        this.validator = validator;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Object getMemberValue(T object) {
+        return getter.apply(object);
+    }
+
+    public  BValidator<R> getValidator() {
+        return validator;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BusinessMemberObject)) return false;
+        BusinessMemberObject<?, ?> that = (BusinessMemberObject<?, ?>) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+}

--- a/src/main/java/io/github/ceoche/bvalid/BusinessMemberObject.java
+++ b/src/main/java/io/github/ceoche/bvalid/BusinessMemberObject.java
@@ -10,9 +10,9 @@ public class BusinessMemberObject<T,R> {
 
     private final Function<T, ?> getter;
 
-    private final Map<Class<?>,BValidator<? extends R>> validators;
+    private final Map<Class<? extends R>,BValidator<? extends R>> validators;
 
-    public BusinessMemberObject(String name, Function<T, ?> getter, Map<Class<?>,BValidator<? extends R>> validators) {
+    BusinessMemberObject(String name, Function<T, ?> getter, Map<Class<? extends R>,BValidator<? extends R>> validators) {
         this.name = name;
         this.getter = getter;
         this.validators = validators;
@@ -26,12 +26,12 @@ public class BusinessMemberObject<T,R> {
         return getter.apply(object);
     }
 
-    public void addValidator(Class<?> clazz, BValidator<?> validator) {
+    void addValidator(Class<? extends R> clazz, BValidator<?> validator) {
         this.validators.put(clazz, (BValidator<? extends R>) validator);
 
     }
 
-    public Map<Class<?>, BValidator<? extends R>> getValidators() {
+    public Map<Class<? extends R>, BValidator<? extends R>> getValidators() {
         return validators;
     }
 

--- a/src/main/java/io/github/ceoche/bvalid/BusinessRuleObject.java
+++ b/src/main/java/io/github/ceoche/bvalid/BusinessRuleObject.java
@@ -1,0 +1,45 @@
+package io.github.ceoche.bvalid;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+public class BusinessRuleObject<T> {
+
+    private final String id;
+
+    private final String description;
+
+    private final Predicate<T> rule;
+
+
+    public BusinessRuleObject(String id, Predicate<T> rule, String description) {
+        this.id = id;
+        this.description = description;
+        this.rule = rule;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Boolean apply(T object) {
+        return rule.test(object);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BusinessRuleObject)) return false;
+        BusinessRuleObject<?> that = (BusinessRuleObject<?>) o;
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/io/github/ceoche/bvalid/BusinessRuleObject.java
+++ b/src/main/java/io/github/ceoche/bvalid/BusinessRuleObject.java
@@ -3,6 +3,12 @@ package io.github.ceoche.bvalid;
 import java.util.Objects;
 import java.util.function.Predicate;
 
+/**
+ * A business rule object is a predicate with an id and a description.
+ * It is used to validate a business object with the manual builder.
+ * It's the equivalent of a {@link BusinessMember} in annotation based validation.
+ * @param <T> the type of the business object to validate
+ */
 public class BusinessRuleObject<T> {
 
     private final String id;
@@ -35,11 +41,13 @@ public class BusinessRuleObject<T> {
         if (this == o) return true;
         if (!(o instanceof BusinessRuleObject)) return false;
         BusinessRuleObject<?> that = (BusinessRuleObject<?>) o;
-        return id.equals(that.id);
+
+        return description.equals(that.description) &&
+                rule.equals(that.rule);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(description, rule);
     }
 }

--- a/src/main/java/io/github/ceoche/bvalid/ObjectResult.java
+++ b/src/main/java/io/github/ceoche/bvalid/ObjectResult.java
@@ -18,7 +18,6 @@ package io.github.ceoche.bvalid;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 /**
  * Aggregate all {@link BusinessRule} and {@link BusinessMember} test results of a
@@ -118,8 +117,8 @@ public class ObjectResult {
 
    private String toString(final String prefix) {
       StringBuilder sb = new StringBuilder();
-      for (RuleResult RuleResult : ruleResults) {
-         sb.append(prefix).append(businessObjectName).append(" ").append(RuleResult.toString()).append(System.lineSeparator());
+      for (RuleResult ruleResult : ruleResults) {
+         sb.append(prefix).append(businessObjectName).append(" ").append(ruleResult.toString()).append(System.lineSeparator());
       }
       if (!memberResults.isEmpty()) {
          String subPrefix = prefix + businessObjectName + ".";

--- a/src/main/java/io/github/ceoche/bvalid/ObjectResult.java
+++ b/src/main/java/io/github/ceoche/bvalid/ObjectResult.java
@@ -32,8 +32,6 @@ public class ObjectResult {
    private final List<RuleResult> ruleResults = new ArrayList<>();
    private final List<ObjectResult> memberResults = new ArrayList<>();
 
-   private static final Pattern INDEX_PATTERN_REGEX = Pattern.compile("\\w+\\[\\d+\\]$");
-
    protected ObjectResult() {
       this("");
    }
@@ -137,17 +135,17 @@ public class ObjectResult {
    /**
     * Get the path of a {@link RuleResult} from the root of the {@link ObjectResult} tree.
     * @param rulePath Ex: "person.address.street[streetNameValid]"
-    * <p>
+    *
     * The path is composed of the business object name, followed by the path of
     * the member, followed by the id of the rule.
-    *     <br>
+    *
     *     <ul>
     *         <li>person is the root {@link ObjectResult}</li>
     *         <li>address is the businessObjectName of {@link BusinessMember} person</li>
     *         <li>street is the businessObjectName of {@link BusinessMember} address</li>
     *         <li>streetNameValid is the id of {@link BusinessRule} street</li>
     *     </ul>
-    * </p>
+    *
     * @return the {@link RuleResult} or null if not found.
     * @throws IllegalArgumentException if a member is not found.
     */

--- a/src/main/java/io/github/ceoche/bvalid/ObjectResult.java
+++ b/src/main/java/io/github/ceoche/bvalid/ObjectResult.java
@@ -18,6 +18,7 @@ package io.github.ceoche.bvalid;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Aggregate all {@link BusinessRule} and {@link BusinessMember} test results of a
@@ -30,6 +31,8 @@ public class ObjectResult {
    private final String businessObjectName;
    private final List<RuleResult> ruleResults = new ArrayList<>();
    private final List<ObjectResult> memberResults = new ArrayList<>();
+
+   private static final Pattern INDEX_PATTERN_REGEX = Pattern.compile("\\w+\\[\\d+\\]$");
 
    protected ObjectResult() {
       this("");
@@ -128,4 +131,55 @@ public class ObjectResult {
       }
       return sb.toString();
    }
+
+   // get RuleResult path from root, ex: "person.address.street[streetNameValid]"
+
+   /**
+    * Get the path of a {@link RuleResult} from the root of the {@link ObjectResult} tree.
+    * @param rulePath Ex: "person.address.street[streetNameValid]"
+    * <p>
+    * The path is composed of the business object name, followed by the path of
+    * the member, followed by the id of the rule.
+    *     <br>
+    *     <ul>
+    *         <li>person is the root {@link ObjectResult}</li>
+    *         <li>address is the businessObjectName of {@link BusinessMember} person</li>
+    *         <li>street is the businessObjectName of {@link BusinessMember} address</li>
+    *         <li>streetNameValid is the id of {@link BusinessRule} street</li>
+    *     </ul>
+    * </p>
+    * @return the {@link RuleResult} or null if not found.
+    * @throws IllegalArgumentException if a member is not found.
+    */
+    public RuleResult getRuleResult(String rulePath) {
+        String[] path = rulePath.split("[\\.\\s]");
+        ObjectResult currentObjectResult = this;
+        if(!path[0].equals(businessObjectName)) {
+            throw new IllegalArgumentException("Rule path does not start with the root object name");
+        }
+        if(path.length == 1) {
+            throw new IllegalArgumentException("Rule path must contain at least one member");
+        }
+        if(elementIsRule(path[1])) {
+           for (RuleResult ruleResult : currentObjectResult.ruleResults) {
+              if(ruleResult.getId().equals(path[1].substring(1, path[1].length() - 1))) {
+                 return ruleResult;
+              }
+           }
+        }
+        else {
+           ObjectResult memberResult = this.memberResults.stream()
+                   .filter(objectResult -> objectResult.businessObjectName.equals(path[1]))
+                   .findFirst()
+                   .orElseThrow(() -> new IllegalArgumentException("Rule path does not match any member"));
+           return memberResult.getRuleResult(rulePath.substring(rulePath.indexOf(".") + 1));
+        }
+        return null;
+    }
+
+    private boolean elementIsRule(String element) {
+        return element.startsWith("[") && element.endsWith("]");
+    }
+
+
 }

--- a/src/main/java/io/github/ceoche/bvalid/ValidatorBuilderSupplier.java
+++ b/src/main/java/io/github/ceoche/bvalid/ValidatorBuilderSupplier.java
@@ -1,0 +1,9 @@
+package io.github.ceoche.bvalid;
+
+import java.util.function.Supplier;
+
+public interface ValidatorBuilderSupplier<T> extends Supplier<BValidatorBuilder<T>> {
+
+    BValidatorBuilder<T> get();
+
+}

--- a/src/main/java/io/github/ceoche/bvalid/ValidatorBuilderSupplier.java
+++ b/src/main/java/io/github/ceoche/bvalid/ValidatorBuilderSupplier.java
@@ -1,9 +1,0 @@
-package io.github.ceoche.bvalid;
-
-import java.util.function.Supplier;
-
-public interface ValidatorBuilderSupplier<T> extends Supplier<BValidatorBuilder<T>> {
-
-    BValidatorBuilder<T> get();
-
-}

--- a/src/main/java/io/github/ceoche/bvalid/ValidatorSupplier.java
+++ b/src/main/java/io/github/ceoche/bvalid/ValidatorSupplier.java
@@ -1,9 +1,0 @@
-package io.github.ceoche.bvalid;
-
-import java.util.function.Supplier;
-
-public interface ValidatorSupplier<T> extends Supplier<BValidator<T>> {
-
-    BValidator<T> get();
-
-}

--- a/src/main/java/io/github/ceoche/bvalid/ValidatorSupplier.java
+++ b/src/main/java/io/github/ceoche/bvalid/ValidatorSupplier.java
@@ -1,0 +1,9 @@
+package io.github.ceoche.bvalid;
+
+import java.util.function.Supplier;
+
+public interface ValidatorSupplier<T> extends Supplier<BValidator<T>> {
+
+    BValidator<T> get();
+
+}

--- a/src/test/java/io/github/ceoche/bvalid/BValidatorAnnotationTest.java
+++ b/src/test/java/io/github/ceoche/bvalid/BValidatorAnnotationTest.java
@@ -24,9 +24,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import static io.github.ceoche.bvalid.BusinessObjectMocks.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BValidatorAnnotationTest {
 

--- a/src/test/java/io/github/ceoche/bvalid/BValidatorBuilderTest.java
+++ b/src/test/java/io/github/ceoche/bvalid/BValidatorBuilderTest.java
@@ -404,6 +404,7 @@ public class BValidatorBuilderTest {
         BValidatorManualBuilder<Graphic> graphicBValidatorManualBuilder = createGraphicValidatorBuilder();
 
         ObjectResult result = graphicBValidatorManualBuilder.build().validate(createGraphic());
+        System.out.println(result);
         assertTrue(result.isValid());
         assertEquals(19, result.getNbOfTests());
         assertTrue(result.getRuleResult("Graphic.shapesList[0] [sqNameValid]").isValid());
@@ -431,10 +432,10 @@ public class BValidatorBuilderTest {
                         .build()
                         .validate(new Graphic()
                         .setName("graphic")
-                        .addShapeToList(new Rectangle().setName("rectangleInList").setHeight(1).setSide(1)))
+                        .addShapeToList(new Circle().setName("circleInList").setRadius(1)))
         );
         assertInstanceOf(IllegalBusinessObjectException.class, throwable.getCause());
-        assertEquals("No validator found for type io.github.ceoche.bvalid.mock.Rectangle", throwable.getCause().getMessage());
+        assertEquals("No validator found for type io.github.ceoche.bvalid.mock.Circle", throwable.getCause().getMessage());
 
     }
 
@@ -522,6 +523,17 @@ public class BValidatorBuilderTest {
         assertTrue(result.isValid());
         assertEquals(1, result.getNbOfTests());
     }
+
+    @Test
+    public void testValidateGraphic(){
+        BValidatorManualBuilder<Graphic> graphicBValidatorManualBuilder = createGraphicValidatorBuilder();
+        Graphic graphic = createGraphic().addShapeToList(new Losange().setName("losange").setDiagonal(10));
+        ObjectResult result = graphicBValidatorManualBuilder.build().validate(graphic);
+        System.out.println(result);
+        assertFalse(result.isValid());
+        assertEquals(22, result.getNbOfTests());
+    }
+
 
 
     private void assertMemberResults(ObjectResult result, boolean expected) {
@@ -612,11 +624,11 @@ public class BValidatorBuilderTest {
                 .setBusinessObjectName("Square")
                 .addRule("sqNameValid", Square::isNameValid, "name is not null")
                 .addRule("sqSideValid", Square::isSideValid, "side is not null");
-        BValidatorManualBuilder<Rectangle> rectangleBValidatorManualBuilder = new BValidatorManualBuilder<>(Rectangle.class)
+        BValidatorManualBuilder<Rectangle> rectangleBValidatorManualBuilder = new BValidatorManualBuilder<>(squareBValidatorManualBuilder,Rectangle.class)
                 .setBusinessObjectName("Rectangle")
-                .addRule("recNameValid", Rectangle::isNameValid, "name is not null")
-                .addRule("recHeightValid", Rectangle::isHeightValid, "height is not null")
-                .addRule("recSideValid", Rectangle::isSideValid, "side is not null");
+//                .addRule("recNameValid", Rectangle::isNameValid, "name is not null")
+                .addRule("recHeightValid", Rectangle::isHeightValid, "height is not null");
+//                .addRule("recSideValid", Rectangle::isSideValid, "side is not null");
         BValidatorManualBuilder<Circle> circleBValidatorManualBuilder = new BValidatorManualBuilder<>(Circle.class)
                 .addRule("crNameValid", Circle::isNameValid, "name is not null")
                 .addRule("crRadiusValid", Circle::isRadiusValid, "radius is not null");

--- a/src/test/java/io/github/ceoche/bvalid/BValidatorBuilderTest.java
+++ b/src/test/java/io/github/ceoche/bvalid/BValidatorBuilderTest.java
@@ -190,7 +190,7 @@ public class BValidatorBuilderTest {
                                 .setAttr1(null)));
 
         ObjectResult result = validator.validate(firstRecursiveObject);
-        System.out.println(result);
+
         assertFalse(result.isValid());
         assertFalse(result.getMemberResults().get(0).getMemberResults().get(0).getRuleResults().get(0).isValid());
 
@@ -215,7 +215,6 @@ public class BValidatorBuilderTest {
                         .setEmail(new Email("aa@bb.com", "aa.com")))
                 .setEmail(new Email("bb@vv", "aa.com"));
         ObjectResult result = validator.validate(firstRecursiveObject);
-        System.out.println(result);
         assertTrue(result.isValid());
     }
 
@@ -274,20 +273,14 @@ public class BValidatorBuilderTest {
                 .setBusinessObjectName("SecondRecursiveObject");
 
         builderFirst.addRule("rule1", FirstRecursiveObject::isAttr1Valid, "attr1 is not null");
-//        builderFirst.addRule("emailValid", FirstRecursiveObject::isEmailValid, "Email must be valid");
         builderFirst.addRule("firstRecursiveObjectValid", FirstRecursiveObject::isFirstRecursiveObjectValid, "firstRecursiveObject in firstRecursiveObject must be valid");
         builderFirst.addRule("secondRecursiveObjectValid", FirstRecursiveObject::isSecondRecursiveObjectValid, "SecondRecursiveObject in firstRecursiveObject must be valid");
         builderFirst.addMember("firstRecursiveObject", FirstRecursiveObject::getFirstRecursiveObject, builderFirst);
-//        builderFirst.addMember("email", FirstRecursiveObject::getEmail, new BValidatorManualBuilder<Email>()
-//                .addRule("emailValid", Email::isEmailValid, "Email must be valid")
-//                .addRule("domainValid", Email::isDomainValid, "Domain must be valid"));
         builderFirst.addMember("secondRecursiveObject", FirstRecursiveObject::getSecondRecursiveObject, builderSecond);
 
         builderSecond.addRule("rule2", SecondRecursiveObject::isAttr2Valid, "attr2 is not null");
         builderSecond.addRule("firstRecursiveObjectValid", SecondRecursiveObject::isFirstRecursiveObjectValid, "firstRecursiveObject in secondRecursiveObject must be valid");
         builderSecond.addMember("firstRecursiveObject", SecondRecursiveObject::getFirstRecursiveObject, builderFirst);
-
-        builderSecond.build();
 
         BValidatorManualBuilder<CollectionRecursiveObject> builderCollection = new BValidatorManualBuilder<CollectionRecursiveObject>()
                 .setBusinessObjectName("CollectionRecursiveObject")
@@ -296,9 +289,6 @@ public class BValidatorBuilderTest {
                 .addRule("secondRecursiveObjectValid", CollectionRecursiveObject::isSecondRecursiveObjectsValid, "secondRecursiveObject in collectionRecursiveObject must be valid")
                 .addMember("firstRecursiveObjects", CollectionRecursiveObject::getFirstRecursiveObjects, builderFirst)
                 .addMember("secondRecursiveObjects", CollectionRecursiveObject::getSecondRecursiveObjects, builderSecond);
-
-        builderSecond.build();
-        builderFirst.build();
 
 
         ObjectResult result = builderCollection.build().validate(new CollectionRecursiveObject()
@@ -373,7 +363,6 @@ public class BValidatorBuilderTest {
 
         ObjectResult result = builderFirst.build().validate(firstLoopObject);
 
-        System.out.println(result);
 
         assertTrue(result.isValid());
         assertEquals(4, result.getNbOfTests());
@@ -397,11 +386,6 @@ public class BValidatorBuilderTest {
         builderSecond.addRule("rule2", SecondRecursiveObject::isAttr2Valid, "attr2 is not null");
         builderSecond.addRule("firstRecursiveObjectValid", SecondRecursiveObject::isFirstRecursiveObjectValid, "firstRecursiveObject in secondRecursiveObject must be valid");
         builderSecond.addMember("firstRecursiveObject", SecondRecursiveObject::getFirstRecursiveObject, builderFirst);
-
-//        builderSecond.build();
-
-//        builderSecond.build();
-//        builderFirst.build();
 
         FirstRecursiveObject firstLoopObject = new FirstRecursiveObject().setAttr1("attr1");
         firstLoopObject.setFirstRecursiveObject(firstLoopObject);

--- a/src/test/java/io/github/ceoche/bvalid/BValidatorBuilderTest.java
+++ b/src/test/java/io/github/ceoche/bvalid/BValidatorBuilderTest.java
@@ -207,7 +207,7 @@ public class BValidatorBuilderTest {
         builder.addMember("firstRecursiveObject", FirstRecursiveObject::getFirstRecursiveObject, builder);
         builder.addMember("email", FirstRecursiveObject::getEmail, new BValidatorManualBuilder<>(Email.class)
                         .addRule("emailValid", Email::isEmailValid, "Email must be valid")
-                        .addRule("domainValid", Email::isDomainValid, "Domain must be valid"))
+                        .addRule("domainValid", Email::isDomainValid, "Domain must be set and not empty"))
                 .build();
         BValidator<FirstRecursiveObject> validator = builder.build();
         FirstRecursiveObject firstRecursiveObject = new FirstRecursiveObject()
@@ -234,7 +234,7 @@ public class BValidatorBuilderTest {
         builderFirst.addMember("firstRecursiveObject", FirstRecursiveObject::getFirstRecursiveObject, builderFirst);
         builderFirst.addMember("email", FirstRecursiveObject::getEmail, new BValidatorManualBuilder<>(Email.class)
                 .addRule("emailValid", Email::isEmailValid, "Email must be valid")
-                .addRule("domainValid", Email::isDomainValid, "Domain must be valid"));
+                .addRule("domainValid", Email::isDomainValid, "Domain must be set and not empty"));
         builderFirst.addMember("secondRecursiveObject", FirstRecursiveObject::getSecondRecursiveObject, builderSecond);
 
         builderSecond.addRule("rule2", SecondRecursiveObject::isAttr2Valid, "attr2 is not null");
@@ -621,7 +621,7 @@ public class BValidatorBuilderTest {
                 .addMember("emails", Person::getEmails, new BValidatorManualBuilder<>(Email.class)
                         .setBusinessObjectName("Email")
                         .addRule("emailValid", Email::isEmailValid, "Email must be valid")
-                        .addRule("domainValid", Email::isDomainValid, "Domain must be valid")
+                        .addRule("domainValid", Email::isDomainValid, "Domain must be set and not empty")
                 );
     }
 

--- a/src/test/java/io/github/ceoche/bvalid/BValidatorBuilderTest.java
+++ b/src/test/java/io/github/ceoche/bvalid/BValidatorBuilderTest.java
@@ -100,11 +100,20 @@ public class BValidatorBuilderTest {
     @Test
     void testBuildValidatorWithWrongMemberCollectionType(){
         assertThrows(IllegalBusinessObjectException.class , () -> new BValidatorBuilderImpl<Person>()
-                .addMember("Adress", (Function<Person, ?>) p->List.of(new Phone("11","+22")), new BValidatorBuilderImpl<Address>()
+                .addMember("Address", (Function<Person, ?>) p->List.of(new Phone("11","+22")), new BValidatorBuilderImpl<Address>()
                         .addRule("rule1", s->true, "Always true"))
                 .build()
                 .validate(createAllCorrectPerson()));
 
+    }
+
+    @Test
+    void testBuildValidatorWithEmptyMemberCollection(){
+        new BValidatorBuilderImpl<Person>()
+                .addMember("Address", (Function<Person, ?>) p->List.of(), new BValidatorBuilderImpl<Address>()
+                        .addRule("rule1", s->true, "Always true"))
+                .build()
+                .validate(createAllCorrectPerson());
     }
 
     @Test

--- a/src/test/java/io/github/ceoche/bvalid/BValidatorBuilderTest.java
+++ b/src/test/java/io/github/ceoche/bvalid/BValidatorBuilderTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -16,35 +17,37 @@ import static org.junit.jupiter.api.Assertions.*;
 public class BValidatorBuilderTest {
 
     @Test
-    public void testBuildValidatorCorrectValidObject(){
+    public void testBuildValidatorCorrectValidObject() {
         BValidatorManualBuilder<Person> builder = createCompleteBuilder();
         assertEquals(3, builder.getRulesCount());
         assertEquals(3, builder.getMembersCount());
         ObjectResult result = builder.build().validate(createAllCorrectPerson());
         assertTrue(result.isValid());
-        for(ObjectResult memberResult : result.getMemberResults()){
+        for (ObjectResult memberResult : result.getMemberResults()) {
             assertTrue(memberResult.toString().contains("true"));
         }
-        for(RuleResult ruleResult : result.getRuleResults()){
+        for (RuleResult ruleResult : result.getRuleResults()) {
             assertTrue(ruleResult.toString().contains("true"));
         }
         assertMemberResults(result, true);
+        System.out.println(result);
 
     }
 
     @Test
-    public void testBuildValidatorCorrectInvalidObject(){
+    public void testBuildValidatorCorrectInvalidObject() {
         BValidatorManualBuilder<Person> builder = createCompleteBuilder();
         assertEquals(3, builder.getRulesCount());
         assertEquals(3, builder.getMembersCount());
         ObjectResult result = builder.build().validate(createPersonWithIncorrectEmailAndPhone());
+        System.out.println(result);
         assertFalse(result.isValid());
-        assertFalse(result.getMemberResults().get(0).getRuleResults().get(1).isValid());
-        assertFalse(result.getMemberResults().get(4).getRuleResults().get(1).isValid());
+        assertFalse(result.getRuleResult("Person.phones[1] [countryCodeValid]").isValid());
+        assertFalse(result.getRuleResult("Person.emails[0] [emailValid]").isValid());
     }
 
     @Test
-    void testBuildValidatorEmpty(){
+    void testBuildValidatorEmpty() {
         BValidatorManualBuilder<Person> builder = new BValidatorManualBuilder<>();
         assertEquals(0, builder.getRulesCount());
         assertEquals(0, builder.getMembersCount());
@@ -54,74 +57,76 @@ public class BValidatorBuilderTest {
     }
 
     @Test
-    void testBuildValidatorWithSameRuleId(){
+    void testBuildValidatorWithSameRuleId() {
         BValidatorManualBuilder<Person> validatorBuilder = new BValidatorManualBuilder<Person>()
-                .addRule("rule1", p->true, "Always true")
-                .addRule("rule1", p->true, "Always true");
+                .addRule("rule1", p -> true, "Always true")
+                .addRule("rule1", p -> true, "Always true");
         assertEquals(1, validatorBuilder.getRulesCount());
     }
 
 
     @Test
-    void testBuildValidatorWithThrowRules(){
+    void testBuildValidatorWithThrowRules() {
         BValidator<Person> validator = new BValidatorManualBuilder<Person>()
-                        .addRule("rule1",
-                                p->{throw new IllegalStateException("Exception in rule1");},
-                                "Name must not be null")
-                        .build();
+                .addRule("rule1",
+                        p -> {
+                            throw new IllegalStateException("Exception in rule1");
+                        },
+                        "Name must not be null")
+                .build();
         Person person = createAllCorrectPerson();
-        Throwable throwable = assertThrows(IllegalStateException.class, ()->validator.validate(person));
+        Throwable throwable = assertThrows(IllegalStateException.class, () -> validator.validate(person));
         assertEquals("Exception in rule1", throwable.getMessage());
     }
 
     @ParameterizedTest
     @MethodSource("provideInvalidMembers")
-    void testBuildValidatorWithNullMember(String memberName, Function<Person, ?> memberFunction, BValidatorBuilder<Person> validatorSupplier){
-        assertThrows(IllegalArgumentException.class, ()->new BValidatorManualBuilder<Person>()
+    void testBuildValidatorWithNullMember(String memberName, Function<Person, ?> memberFunction, BValidatorBuilder<Person> validatorSupplier) {
+        assertThrows(IllegalArgumentException.class, () -> new BValidatorManualBuilder<Person>()
                 .addMember(memberName, memberFunction, validatorSupplier));
     }
 
 
     @ParameterizedTest
     @MethodSource("provideInvalidRules")
-    void testBuildValidatorWithNullRule(String ruleId, Predicate<Person> rule, String message){
-        assertThrows(IllegalArgumentException.class, ()->new BValidatorManualBuilder<Person>()
+    void testBuildValidatorWithNullRule(String ruleId, Predicate<Person> rule, String message) {
+        assertThrows(IllegalArgumentException.class, () -> new BValidatorManualBuilder<Person>()
                 .addRule(ruleId, rule, message));
     }
 
     @Test
-    void testBuildValidatorWithNullMemberGetter(){
+    void testBuildValidatorWithNullMemberGetter() {
         new BValidatorManualBuilder<Person>()
-                .addMember("name", (Function<Person, ?>) p->null, new BValidatorManualBuilder<Address>()
-                        .addRule("rule1", s->true, "Always true"))
+                .addMember("name", (Function<Person, ?>) p -> null, new BValidatorManualBuilder<Address>()
+                        .addRule("rule1", s -> true, "Always true"))
                 .build()
                 .validate(createAllCorrectPerson());
     }
 
     @Test
-    void testBuildValidatorWithWrongMemberCollectionType(){
-        assertThrows(IllegalBusinessObjectException.class , () -> new BValidatorManualBuilder<Person>()
-                .addMember("Address", (Function<Person, ?>) p->List.of(new Phone("11","+22")), new BValidatorManualBuilder<Address>()
-                        .addRule("rule1", s->true, "Always true"))
+    void testBuildValidatorWithWrongMemberCollectionType() {
+        assertThrows(IllegalBusinessObjectException.class, () -> new BValidatorManualBuilder<Person>()
+                .addMember("Address", (Function<Person, ?>) p -> List.of(new Phone("11", "+22")), new BValidatorManualBuilder<Address>()
+                        .addRule("rule1", s -> true, "Always true"))
                 .build()
                 .validate(createAllCorrectPerson()));
 
     }
 
     @Test
-    void testBuildValidatorWithEmptyMemberCollection(){
+    void testBuildValidatorWithEmptyMemberCollection() {
         new BValidatorManualBuilder<Person>()
-                .addMember("Address", (Function<Person, ?>) p->List.of(), new BValidatorManualBuilder<Address>()
-                        .addRule("rule1", s->true, "Always true"))
+                .addMember("Address", (Function<Person, ?>) p -> List.of(), new BValidatorManualBuilder<Address>()
+                        .addRule("rule1", s -> true, "Always true"))
                 .build()
                 .validate(createAllCorrectPerson());
     }
 
     @Test
-    void testCompareRules(){
-        BusinessRuleObject<Person> rule1 = new BusinessRuleObject<>("rule1", p->true, "Always true");
-        BusinessRuleObject<Person> rule2 = new BusinessRuleObject<>("rule1", p->true, "Always true");
-        BusinessRuleObject<Person> rule3 = new BusinessRuleObject<>("rule2", p->true, "Always true");
+    void testCompareRules() {
+        BusinessRuleObject<Person> rule1 = new BusinessRuleObject<>("rule1", p -> true, "Always true");
+        BusinessRuleObject<Person> rule2 = new BusinessRuleObject<>("rule1", p -> true, "Always true");
+        BusinessRuleObject<Person> rule3 = new BusinessRuleObject<>("rule2", p -> true, "Always true");
         assertEquals(rule1, rule2);
         assertNotEquals(rule1, rule3);
         assertEquals(rule1, rule1);
@@ -129,20 +134,20 @@ public class BValidatorBuilderTest {
     }
 
     @Test
-    void testCompareMembers(){
+    void testCompareMembers() {
         BusinessMemberObject<Person, Address> member1 = new BusinessMemberObject<>("member1",
                 Person::getAddress,
                 new BValidatorManualBuilder<Address>()
-                    .addRule("rule1", s->true, "Always true")
-                    .build());
+                        .addRule("rule1", s -> true, "Always true")
+                        .build());
         BusinessMemberObject<Person, Email> member2 = new BusinessMemberObject<>("member1", Person::getEmails,
                 new BValidatorManualBuilder<Email>()
-                    .addRule("rule1", s->true, "Always true")
-                    .build());
+                        .addRule("rule1", s -> true, "Always true")
+                        .build());
         BusinessMemberObject<Person, Phone> member3 = new BusinessMemberObject<>("member2", Person::getPhones,
                 new BValidatorManualBuilder<Phone>()
-                    .addRule("rule1", s->true, "Always true")
-                    .build());
+                        .addRule("rule1", s -> true, "Always true")
+                        .build());
         assertEquals(member1, member2);
         assertNotEquals(member1, member3);
         assertEquals(member1, member1);
@@ -150,14 +155,273 @@ public class BValidatorBuilderTest {
 
     }
 
-    private void assertMemberResults(ObjectResult result, boolean expected){
-        for(ObjectResult memberResult : result.getMemberResults()){
+    @Test
+    void testRecursiveObject() {
+        BValidatorManualBuilder<FirstRecursiveObject> builder = new BValidatorManualBuilder<FirstRecursiveObject>()
+                .setBusinessObjectName("FirstRecursiveObject");
+        builder.addRule("rule1", FirstRecursiveObject::isAttr1Valid, "Always true");
+        builder.addMember("firstRecursiveObject", FirstRecursiveObject::getFirstRecursiveObject, builder);
+        BValidator<FirstRecursiveObject> validator = builder.build();
+        FirstRecursiveObject firstRecursiveObject = new FirstRecursiveObject()
+                .setAttr1("attr1")
+                .setFirstRecursiveObject(new FirstRecursiveObject()
+                        .setAttr1("attr2")
+                        .setFirstRecursiveObject(new FirstRecursiveObject()
+                                .setAttr1("attr3")
+                                .setFirstRecursiveObject(new FirstRecursiveObject()
+                                        .setAttr1("attr4"))));
+        ObjectResult result = validator.validate(firstRecursiveObject);
+        System.out.println(result);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void testRecursiveObjectWithNull() {
+        BValidatorManualBuilder<FirstRecursiveObject> builder = new BValidatorManualBuilder<FirstRecursiveObject>()
+                .setBusinessObjectName("FirstRecursiveObject");
+        builder.addRule("rule1", FirstRecursiveObject::isAttr1Valid, "Always true");
+        builder.addMember("firstRecursiveObject", FirstRecursiveObject::getFirstRecursiveObject, builder);
+        BValidator<FirstRecursiveObject> validator = builder.build();
+        FirstRecursiveObject firstRecursiveObject = new FirstRecursiveObject()
+                .setAttr1("attr1")
+                .setFirstRecursiveObject(new FirstRecursiveObject()
+                        .setAttr1("attr2")
+                        .setFirstRecursiveObject(new FirstRecursiveObject()
+                                .setAttr1(null)));
+
+        ObjectResult result = validator.validate(firstRecursiveObject);
+        System.out.println(result);
+        assertFalse(result.isValid());
+        assertFalse(result.getMemberResults().get(0).getMemberResults().get(0).getRuleResults().get(0).isValid());
+
+    }
+
+    @Test
+    void testRecursiveObjectWithSubElement() {
+        BValidatorManualBuilder<FirstRecursiveObject> builder = new BValidatorManualBuilder<FirstRecursiveObject>()
+                .setBusinessObjectName("FirstRecursiveObject");
+        builder.addRule("rule1", FirstRecursiveObject::isAttr1Valid, "attr1 is not null");
+        builder.addRule("emailValid", FirstRecursiveObject::isEmailValid, "Email must be valid");
+        builder.addMember("firstRecursiveObject", FirstRecursiveObject::getFirstRecursiveObject, builder);
+        builder.addMember("email", FirstRecursiveObject::getEmail, new BValidatorManualBuilder<Email>()
+                        .addRule("emailValid", Email::isEmailValid, "Email must be valid")
+                        .addRule("domainValid", Email::isDomainValid, "Domain must be valid"))
+                .build();
+        BValidator<FirstRecursiveObject> validator = builder.build();
+        FirstRecursiveObject firstRecursiveObject = new FirstRecursiveObject()
+                .setAttr1("attr1")
+                .setFirstRecursiveObject(new FirstRecursiveObject()
+                        .setAttr1("attr2")
+                        .setEmail(new Email("aa@bb.com", "aa.com")))
+                .setEmail(new Email("bb@vv", "aa.com"));
+        ObjectResult result = validator.validate(firstRecursiveObject);
+        System.out.println(result);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void testCrossRecursiveObject() {
+        BValidatorManualBuilder<FirstRecursiveObject> builderFirst = new BValidatorManualBuilder<FirstRecursiveObject>()
+                .setBusinessObjectName("FirstRecursiveObject");
+        BValidatorManualBuilder<SecondRecursiveObject> builderSecond = new BValidatorManualBuilder<SecondRecursiveObject>()
+                .setBusinessObjectName("SecondRecursiveObject");
+
+        builderFirst.addRule("rule1", FirstRecursiveObject::isAttr1Valid, "attr1 is not null");
+        builderFirst.addRule("emailValid", FirstRecursiveObject::isEmailValid, "Email must be valid");
+        builderFirst.addRule("firstRecursiveObjectValid", FirstRecursiveObject::isFirstRecursiveObjectValid, "firstRecursiveObject in firstRecursiveObject must be valid");
+        builderFirst.addRule("secondRecursiveObjectValid", FirstRecursiveObject::isSecondRecursiveObjectValid, "SecondRecursiveObject in firstRecursiveObject must be valid");
+        builderFirst.addMember("firstRecursiveObject", FirstRecursiveObject::getFirstRecursiveObject, builderFirst);
+        builderFirst.addMember("email", FirstRecursiveObject::getEmail, new BValidatorManualBuilder<Email>()
+                .addRule("emailValid", Email::isEmailValid, "Email must be valid")
+                .addRule("domainValid", Email::isDomainValid, "Domain must be valid"));
+        builderFirst.addMember("secondRecursiveObject", FirstRecursiveObject::getSecondRecursiveObject, builderSecond);
+
+        builderSecond.addRule("rule2", SecondRecursiveObject::isAttr2Valid, "attr2 is not null");
+        builderSecond.addRule("firstRecursiveObjectValid", SecondRecursiveObject::isFirstRecursiveObjectValid, "firstRecursiveObject in secondRecursiveObject must be valid");
+        builderSecond.addMember("firstRecursiveObject", SecondRecursiveObject::getFirstRecursiveObject, builderFirst);
+
+        builderSecond.build();
+
+        ObjectResult result = builderFirst.build().validate(new FirstRecursiveObject()
+                .setAttr1("attr1")
+                .setEmail(new Email("aa@bb", "ff.v"))
+                .setFirstRecursiveObject(new FirstRecursiveObject()
+                        .setAttr1("attr1.2")
+                        .setEmail(new Email("aa@vv", "ff.v"))
+                        .setSecondRecursiveObject(new SecondRecursiveObject()
+                                .setFirstRecursiveObject(new FirstRecursiveObject()
+                                        .setAttr1("attr2.1"))
+                                .setAttr2("attr2")))
+                .setSecondRecursiveObject(new SecondRecursiveObject()
+                        .setFirstRecursiveObject(new FirstRecursiveObject()
+                                .setAttr1(null))
+                        .setAttr2("attr2")));
+        assertEquals(19, countAllRulesResults(result, true));
+        assertEquals(5, countAllRulesResults(result, false));
+        assertFalse(result.getRuleResult("FirstRecursiveObject.secondRecursiveObject.firstRecursiveObject [secondRecursiveObjectValid]").isValid());
+        assertFalse(result.getRuleResult("FirstRecursiveObject.secondRecursiveObject.firstRecursiveObject [rule1]").isValid());
+        assertFalse(result.getRuleResult("FirstRecursiveObject.secondRecursiveObject.firstRecursiveObject [emailValid]").isValid());
+        assertFalse(result.getRuleResult("FirstRecursiveObject.firstRecursiveObject.secondRecursiveObject.firstRecursiveObject [secondRecursiveObjectValid]").isValid());
+        assertFalse(result.getRuleResult("FirstRecursiveObject.firstRecursiveObject.secondRecursiveObject.firstRecursiveObject [emailValid]").isValid());
+
+    }
+
+    @Test
+    public void testCrossCollectionRecursiveObject(){
+        BValidatorManualBuilder<FirstRecursiveObject> builderFirst = new BValidatorManualBuilder<FirstRecursiveObject>()
+                .setBusinessObjectName("FirstRecursiveObject");
+        BValidatorManualBuilder<SecondRecursiveObject> builderSecond = new BValidatorManualBuilder<SecondRecursiveObject>()
+                .setBusinessObjectName("SecondRecursiveObject");
+
+        builderFirst.addRule("rule1", FirstRecursiveObject::isAttr1Valid, "attr1 is not null");
+//        builderFirst.addRule("emailValid", FirstRecursiveObject::isEmailValid, "Email must be valid");
+        builderFirst.addRule("firstRecursiveObjectValid", FirstRecursiveObject::isFirstRecursiveObjectValid, "firstRecursiveObject in firstRecursiveObject must be valid");
+        builderFirst.addRule("secondRecursiveObjectValid", FirstRecursiveObject::isSecondRecursiveObjectValid, "SecondRecursiveObject in firstRecursiveObject must be valid");
+        builderFirst.addMember("firstRecursiveObject", FirstRecursiveObject::getFirstRecursiveObject, builderFirst);
+//        builderFirst.addMember("email", FirstRecursiveObject::getEmail, new BValidatorManualBuilder<Email>()
+//                .addRule("emailValid", Email::isEmailValid, "Email must be valid")
+//                .addRule("domainValid", Email::isDomainValid, "Domain must be valid"));
+        builderFirst.addMember("secondRecursiveObject", FirstRecursiveObject::getSecondRecursiveObject, builderSecond);
+
+        builderSecond.addRule("rule2", SecondRecursiveObject::isAttr2Valid, "attr2 is not null");
+        builderSecond.addRule("firstRecursiveObjectValid", SecondRecursiveObject::isFirstRecursiveObjectValid, "firstRecursiveObject in secondRecursiveObject must be valid");
+        builderSecond.addMember("firstRecursiveObject", SecondRecursiveObject::getFirstRecursiveObject, builderFirst);
+
+        builderSecond.build();
+
+        BValidatorManualBuilder<CollectionRecursiveObject> builderCollection = new BValidatorManualBuilder<CollectionRecursiveObject>()
+                .setBusinessObjectName("CollectionRecursiveObject")
+                .addRule("rule3", CollectionRecursiveObject::isCollectionAttrValid, "collection attr is not null")
+                .addRule("firstRecursiveObjectValid", CollectionRecursiveObject::isFirstRecursiveObjectsValid, "firstRecursiveObject in collectionRecursiveObject must be valid")
+                .addRule("secondRecursiveObjectValid", CollectionRecursiveObject::isSecondRecursiveObjectsValid, "secondRecursiveObject in collectionRecursiveObject must be valid")
+                .addMember("firstRecursiveObjects", CollectionRecursiveObject::getFirstRecursiveObjects, builderFirst)
+                .addMember("secondRecursiveObjects", CollectionRecursiveObject::getSecondRecursiveObjects, builderSecond);
+
+        builderSecond.build();
+        builderFirst.build();
+
+
+        ObjectResult result = builderCollection.build().validate(new CollectionRecursiveObject()
+                .setCollectionAttr("collectionAttr")
+                .setFirstRecursiveObjects(new FirstRecursiveObject[]{
+                        new FirstRecursiveObject()
+                                .setAttr1("attr[0]1")
+                                .setFirstRecursiveObject(new FirstRecursiveObject()
+                                        .setAttr1("attr[0]1.2")
+                                        .setSecondRecursiveObject(new SecondRecursiveObject()
+                                                .setFirstRecursiveObject(new FirstRecursiveObject()
+                                                        .setAttr1("attr2.1"))
+                                                .setAttr2("attr2")))
+                                .setSecondRecursiveObject(new SecondRecursiveObject()
+                                        .setFirstRecursiveObject(new FirstRecursiveObject()
+                                                .setAttr1(null))
+                                        .setAttr2("attr2")),
+                        new FirstRecursiveObject()
+                                .setAttr1("attr[1]1")
+                                .setFirstRecursiveObject(new FirstRecursiveObject()
+                                        .setAttr1("attr[0]1.2")
+                                        .setEmail(new Email("aa@vv", "ff.v"))
+                        )
+                })
+                .setSecondRecursiveObjects(List.of(
+                        new SecondRecursiveObject()
+                                .setAttr2("attr[0]2")
+                                .setFirstRecursiveObject(new FirstRecursiveObject()
+                                        .setAttr1("attr[0]2.1")
+                                        .setFirstRecursiveObject(new FirstRecursiveObject()
+                                                .setAttr1("attr[0]2.1.1")
+                                                .setSecondRecursiveObject(new SecondRecursiveObject()
+                                                        .setAttr2("attr[0]2.1.1.2")
+                                                        .setFirstRecursiveObject(new FirstRecursiveObject()
+                                                                .setAttr1("attr[0]2.1.1.2.1"))
+                                                )
+                                        )
+                                        .setSecondRecursiveObject(new SecondRecursiveObject()
+                                                .setAttr2("attr[0]2.1.2")
+                                                .setFirstRecursiveObject(new FirstRecursiveObject()
+                                                        .setAttr1(null)) // invalid attr[0]2.1.2.1
+                                        )
+                                )
+                        ,
+                        new SecondRecursiveObject()
+                                .setAttr2("attr[1]2")
+                                .setFirstRecursiveObject(new FirstRecursiveObject()
+                                        .setAttr1("attr[1]2.1")
+                                        .setFirstRecursiveObject(new FirstRecursiveObject()
+                                                .setAttr1("attr[1]2.1.1")
+                                        )
+                                )
+                        )
+                )
+        );
+        assertFalse(result.isValid());
+        assertEquals(10, countAllRulesResults(result, false));
+        assertFalse(result.getRuleResult("CollectionRecursiveObject.secondRecursiveObjects[0].firstRecursiveObject.secondRecursiveObject.firstRecursiveObject [secondRecursiveObjectValid]").isValid());
+
+    }
+
+    @Test
+    public void testRecursiveLoopObject() {
+        BValidatorManualBuilder<FirstRecursiveObject> builderFirst = new BValidatorManualBuilder<FirstRecursiveObject>()
+                .setBusinessObjectName("FirstRecursiveObject")
+                .addRule("rule1", FirstRecursiveObject::isAttr1Valid, "attr1 is not null")
+                .addRule("firstRecursiveObjectValid", FirstRecursiveObject::isFirstRecursiveObjectValid, "firstRecursiveObject in firstRecursiveObject must be valid");
+        builderFirst.addMember("firstRecursiveObject", FirstRecursiveObject::getFirstRecursiveObject, builderFirst);
+
+        FirstRecursiveObject firstLoopObject = new FirstRecursiveObject().setAttr1("attr1");
+        firstLoopObject.setFirstRecursiveObject(firstLoopObject);
+
+        ObjectResult result = builderFirst.build().validate(firstLoopObject);
+
+        System.out.println(result);
+
+        assertTrue(result.isValid());
+        assertEquals(4, result.getNbOfTests());
+        assertEquals(4, countAllRulesResults(result, true));
+
+    }
+
+    @Test
+    public void testRecursiveCrossLoopObject() {
+        BValidatorManualBuilder<FirstRecursiveObject> builderFirst = new BValidatorManualBuilder<FirstRecursiveObject>()
+                .setBusinessObjectName("FirstRecursiveObject");
+        BValidatorManualBuilder<SecondRecursiveObject> builderSecond = new BValidatorManualBuilder<SecondRecursiveObject>()
+                .setBusinessObjectName("SecondRecursiveObject");
+
+        builderFirst.addRule("rule1", FirstRecursiveObject::isAttr1Valid, "attr1 is not null");
+        builderFirst.addRule("firstRecursiveObjectValid", FirstRecursiveObject::isFirstRecursiveObjectValid, "firstRecursiveObject in firstRecursiveObject must be valid");
+        builderFirst.addRule("secondRecursiveObjectValid", FirstRecursiveObject::isSecondRecursiveObjectValid, "SecondRecursiveObject in firstRecursiveObject must be valid");
+        builderFirst.addMember("firstRecursiveObject", FirstRecursiveObject::getFirstRecursiveObject, builderFirst);
+        builderFirst.addMember("secondRecursiveObject", FirstRecursiveObject::getSecondRecursiveObject, builderSecond);
+
+        builderSecond.addRule("rule2", SecondRecursiveObject::isAttr2Valid, "attr2 is not null");
+        builderSecond.addRule("firstRecursiveObjectValid", SecondRecursiveObject::isFirstRecursiveObjectValid, "firstRecursiveObject in secondRecursiveObject must be valid");
+        builderSecond.addMember("firstRecursiveObject", SecondRecursiveObject::getFirstRecursiveObject, builderFirst);
+
+//        builderSecond.build();
+
+//        builderSecond.build();
+//        builderFirst.build();
+
+        FirstRecursiveObject firstLoopObject = new FirstRecursiveObject().setAttr1("attr1");
+        firstLoopObject.setFirstRecursiveObject(firstLoopObject);
+        SecondRecursiveObject secondLoopObject = new SecondRecursiveObject().setAttr2("attr2");
+        firstLoopObject.setSecondRecursiveObject(secondLoopObject);
+        secondLoopObject.setFirstRecursiveObject(firstLoopObject);
+
+        ObjectResult result = builderFirst.build().validate(firstLoopObject);
+        assertTrue(result.isValid());
+        assertEquals(8, result.getNbOfTests());
+    }
+
+    private void assertMemberResults(ObjectResult result, boolean expected) {
+        for (ObjectResult memberResult : result.getMemberResults()) {
             assertEquals(expected, memberResult.isValid());
             assertMemberResults(memberResult, expected);
         }
     }
 
-    private static Stream<Arguments> provideInvalidMembers(){
+    private static Stream<Arguments> provideInvalidMembers() {
         return Stream.of(
                 Arguments.of(null, (Function<Person, Object>) Person::getAddress, null),
                 Arguments.of("name", null, null),
@@ -165,9 +429,9 @@ public class BValidatorBuilderTest {
         );
     }
 
-    private static Stream<Arguments> provideInvalidRules(){
+    private static Stream<Arguments> provideInvalidRules() {
         return Stream.of(
-                Arguments.of(null, (Predicate<Person>) p->true, "message"),
+                Arguments.of(null, (Predicate<Person>) p -> true, "message"),
                 Arguments.of("rule1", null, "message"),
                 Arguments.of(null, null, null)
         );
@@ -192,8 +456,7 @@ public class BValidatorBuilderTest {
     }
 
 
-
-    private BValidatorManualBuilder<Person> createCompleteBuilder(){
+    private BValidatorManualBuilder<Person> createCompleteBuilder() {
         return new BValidatorManualBuilder<Person>()
                 .setBusinessObjectName("Person")
                 .addRule("ageValid", Person::isAgeValid, "Name must not be null")
@@ -203,24 +466,41 @@ public class BValidatorBuilderTest {
                         .setBusinessObjectName("Address")
                         .addRule("cityValid", Address::isCityValid, "City must not be null")
                         .addRule("StreetValid", Address::isStreetValid, "Street must not be empty")
-                        .addMember("city", Address::getCity,  new BValidatorManualBuilder<City>()
+                        .addMember("city", Address::getCity, new BValidatorManualBuilder<City>()
                                 .setBusinessObjectName("City")
                                 .addRule("cityNameValid", City::isNamesValid, "City name must not be empty")
                                 .addRule("cityZipcodeValid", City::isZipCodeValid, "City zipcode must be valid")
-                                )
                         )
-                .addMember("phones", Person::getPhones,  new BValidatorManualBuilder<Phone>()
+                )
+                .addMember("phones", Person::getPhones, new BValidatorManualBuilder<Phone>()
                         .setBusinessObjectName("Phone")
                         .addRule("numberValid", Phone::isNumberValid, "Number must not be null")
                         .addRule("countryCodeValid", Phone::isCountryCodeValid, "Country code must not be valid")
-                        )
+                )
                 .addMember("emails", Person::getEmails, new BValidatorManualBuilder<Email>()
                         .setBusinessObjectName("Email")
                         .addRule("emailValid", Email::isEmailValid, "Email must be valid")
                         .addRule("domainValid", Email::isDomainValid, "Domain must be valid")
-                        );
+                );
     }
 
+    //count number of (Ture of False) rules in the result recursively
+    private int countAllRulesResults(ObjectResult result, boolean expected) {
+        int count = countRulesResults(result, expected);
+        for (ObjectResult memberResult : result.getMemberResults()) {
+            count += countAllRulesResults(memberResult, expected);
+        }
+        return count;
+    }
 
+    public int countRulesResults(ObjectResult result, boolean expected) {
+        int count = 0;
+        for (RuleResult ruleResult : result.getRuleResults()) {
+            if (ruleResult.isValid() == expected) {
+                count++;
+            }
+        }
+        return count;
+    }
 
 }

--- a/src/test/java/io/github/ceoche/bvalid/BValidatorBuilderTest.java
+++ b/src/test/java/io/github/ceoche/bvalid/BValidatorBuilderTest.java
@@ -58,9 +58,10 @@ public class BValidatorBuilderTest {
 
     @Test
     void testBuildValidatorWithSameRuleId() {
+        Predicate<Person> rule = p -> true;
         BValidatorManualBuilder<Person> validatorBuilder = new BValidatorManualBuilder<>(Person.class)
-                .addRule("rule1", p -> true, "Always true")
-                .addRule("rule1", p -> true, "Always true");
+                .addRule("rule1", rule, "Always true")
+                .addRule("rule1", rule, "Always true");
         assertEquals(1, validatorBuilder.getRulesCount());
     }
 
@@ -87,11 +88,10 @@ public class BValidatorBuilderTest {
     }
 
 
-    @ParameterizedTest
-    @MethodSource("provideInvalidRules")
-    void testBuildValidatorWithNullRule(String ruleId, Predicate<Person> rule, String message) {
+    @Test
+    void testBuildValidatorWithNullRule() {
         assertThrows(IllegalArgumentException.class, () -> new BValidatorManualBuilder<>(Person.class)
-                .addRule(ruleId, rule, message));
+                .addRule("rule", null, "message"));
     }
 
     @Test
@@ -124,9 +124,11 @@ public class BValidatorBuilderTest {
 
     @Test
     void testCompareRules() {
-        BusinessRuleObject<Person> rule1 = new BusinessRuleObject<>("rule1", p -> true, "Always true");
-        BusinessRuleObject<Person> rule2 = new BusinessRuleObject<>("rule1", p -> true, "Always true");
-        BusinessRuleObject<Person> rule3 = new BusinessRuleObject<>("rule2", p -> true, "Always true");
+        Predicate<Person> predicate1 = p -> true;
+        Predicate<Person> predicate2 = p -> true;
+        BusinessRuleObject<Person> rule1 = new BusinessRuleObject<>("rule1", predicate1, "Rule 1 Always true");
+        BusinessRuleObject<Person> rule2 = new BusinessRuleObject<>("rule1", predicate1, "Rule 1 Always true");
+        BusinessRuleObject<Person> rule3 = new BusinessRuleObject<>("rule2", predicate2, "Rule 2 Always true");
         assertEquals(rule1, rule2);
         assertNotEquals(rule1, rule3);
         assertEquals(rule1, rule1);
@@ -534,6 +536,17 @@ public class BValidatorBuilderTest {
         assertEquals(22, result.getNbOfTests());
     }
 
+    @Test
+    public void testAddMemberWithoutId(){
+        BValidator<Phone> bValidator = new BValidatorManualBuilder<>(Phone.class)
+                .setBusinessObjectName("phone")
+                .addRule(Phone::isCountryCodeValid, "country code is not valid")
+                .addRule(Phone::isNumberValid, "number is not valid")
+                .build();
+        ObjectResult result = bValidator.validate(new Phone("01234567", "+33"));
+        assertTrue(result.isValid());
+    }
+
 
 
     private void assertMemberResults(ObjectResult result, boolean expected) {
@@ -551,13 +564,6 @@ public class BValidatorBuilderTest {
         );
     }
 
-    private static Stream<Arguments> provideInvalidRules() {
-        return Stream.of(
-                Arguments.of(null, (Predicate<Person>) p -> true, "message"),
-                Arguments.of("rule1", null, "message"),
-                Arguments.of(null, null, null)
-        );
-    }
 
     private Person createAllCorrectPerson() {
         return new Person(
@@ -626,9 +632,7 @@ public class BValidatorBuilderTest {
                 .addRule("sqSideValid", Square::isSideValid, "side is not null");
         BValidatorManualBuilder<Rectangle> rectangleBValidatorManualBuilder = new BValidatorManualBuilder<>(squareBValidatorManualBuilder,Rectangle.class)
                 .setBusinessObjectName("Rectangle")
-//                .addRule("recNameValid", Rectangle::isNameValid, "name is not null")
                 .addRule("recHeightValid", Rectangle::isHeightValid, "height is not null");
-//                .addRule("recSideValid", Rectangle::isSideValid, "side is not null");
         BValidatorManualBuilder<Circle> circleBValidatorManualBuilder = new BValidatorManualBuilder<>(Circle.class)
                 .addRule("crNameValid", Circle::isNameValid, "name is not null")
                 .addRule("crRadiusValid", Circle::isRadiusValid, "radius is not null");

--- a/src/test/java/io/github/ceoche/bvalid/BValidatorBuilderTest.java
+++ b/src/test/java/io/github/ceoche/bvalid/BValidatorBuilderTest.java
@@ -1,0 +1,193 @@
+package io.github.ceoche.bvalid;
+
+import io.github.ceoche.bvalid.mock.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BValidatorBuilderTest {
+
+    @Test
+    public void testBuildValidatorCorrectValidObject(){
+        BValidatorBuilderImpl<Person> builder = createCompleteBuilder();
+        assertEquals(3, builder.getRulesCount());
+        assertEquals(3, builder.getMembersCount());
+        ObjectResult result = builder.build().validate(createAllCorrectPerson());
+        assertTrue(result.isValid());
+        for(ObjectResult memberResult : result.getMemberResults()){
+            assertTrue(memberResult.toString().contains("true"));
+        }
+        for(RuleResult ruleResult : result.getRuleResults()){
+            assertTrue(ruleResult.toString().contains("true"));
+        }
+        assertMemberResults(result, true);
+
+    }
+
+    @Test
+    public void testBuildValidatorCorrectInvalidObject(){
+        BValidatorBuilderImpl<Person> builder = createCompleteBuilder();
+        assertEquals(3, builder.getRulesCount());
+        assertEquals(3, builder.getMembersCount());
+        ObjectResult result = builder.build().validate(createPersonWithIncorrectEmailAndPhone());
+        assertFalse(result.isValid());
+        assertFalse(result.getMemberResults().get(0).getRuleResults().get(1).isValid());
+        assertFalse(result.getMemberResults().get(4).getRuleResults().get(1).isValid());
+    }
+
+    @Test
+    void testBuildValidatorEmpty(){
+        BValidatorBuilderImpl<Person> builder = new BValidatorBuilderImpl<>();
+        assertEquals(0, builder.getRulesCount());
+        assertEquals(0, builder.getMembersCount());
+        Throwable exception = assertThrows(IllegalBusinessObjectException.class, builder::build);
+        assertEquals("Rules or members must be provided for a business object: ", exception.getMessage());
+    }
+
+    @Test
+    void testBuildValidatorWithSameRuleId(){
+        BValidatorBuilderImpl<Person> validatorBuilder = new BValidatorBuilderImpl<Person>()
+                .addRule("rule1", p->true, "Always true")
+                .addRule("rule1", p->true, "Always true");
+        assertEquals(1, validatorBuilder.getRulesCount());
+    }
+
+
+    @Test
+    void testBuildValidatorWithThrowRules(){
+        BValidator<Person> validator = new BValidatorBuilderImpl<Person>()
+                        .addRule("rule1",
+                                p->{throw new IllegalStateException("Exception in rule1");},
+                                "Name must not be null")
+                        .build();
+        Person person = createAllCorrectPerson();
+        Throwable throwable = assertThrows(IllegalStateException.class, ()->validator.validate(person));
+        assertEquals("Exception in rule1", throwable.getMessage());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidMembers")
+    void testBuildValidatorWithNullMember(String memberName, Function<Person, ?> memberFunction, BValidatorBuilder<Person> validatorSupplier){
+        assertThrows(IllegalArgumentException.class, ()->new BValidatorBuilderImpl<Person>()
+                .addMember(memberName, memberFunction, validatorSupplier));
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidRules")
+    void testBuildValidatorWithNullRule(String ruleId, Predicate<Person> rule, String message){
+        assertThrows(IllegalArgumentException.class, ()->new BValidatorBuilderImpl<Person>()
+                .addRule(ruleId, rule, message));
+    }
+
+    @Test
+    void testBuildValidatorWithNullMemberGetter(){
+        new BValidatorBuilderImpl<Person>()
+                .addMember("name", (Function<Person, ?>) p->null, new BValidatorBuilderImpl<Address>()
+                        .addRule("rule1", s->true, "Always true"))
+                .build()
+                .validate(createAllCorrectPerson());
+    }
+
+    @Test
+    void testBuildValidatorWithWrongMemberCollectionType(){
+        assertThrows(IllegalBusinessObjectException.class , () -> new BValidatorBuilderImpl<Person>()
+                .addMember("Adress", (Function<Person, ?>) p->List.of(new Phone("11","+22")), new BValidatorBuilderImpl<Address>()
+                        .addRule("rule1", s->true, "Always true"))
+                .build()
+                .validate(createAllCorrectPerson()));
+
+    }
+
+    @Test
+    void testCompareRules(){
+        BusinessRuleObject<Person> rule1 = new BusinessRuleObject<>("rule1", p->true, "Always true");
+        BusinessRuleObject<Person> rule2 = new BusinessRuleObject<>("rule1", p->true, "Always true");
+        BusinessRuleObject<Person> rule3 = new BusinessRuleObject<>("rule2", p->true, "Always true");
+        assertEquals(rule1, rule2);
+        assertNotEquals(rule1, rule3);
+    }
+
+
+    private void assertMemberResults(ObjectResult result, boolean expected){
+        for(ObjectResult memberResult : result.getMemberResults()){
+            assertEquals(expected, memberResult.isValid());
+            assertMemberResults(memberResult, expected);
+        }
+    }
+
+    private static Stream<Arguments> provideInvalidMembers(){
+        return Stream.of(
+                Arguments.of(null, (Function<Person, Object>) Person::getAddress, null),
+                Arguments.of("name", null, null),
+                Arguments.of("name", (Function<Person, Object>) Person::getAddress, null)
+        );
+    }
+
+    private static Stream<Arguments> provideInvalidRules(){
+        return Stream.of(
+                Arguments.of(null, (Predicate<Person>) p->true, "message"),
+                Arguments.of("rule1", null, "message"),
+                Arguments.of(null, null, null)
+        );
+    }
+
+    private Person createAllCorrectPerson() {
+        return new Person(
+                "John",
+                new Address("Main Street", new City("Paris", 75000), "France"),
+                35,
+                new Email[]{new Email("aa@bb.cc", "bb.cc"), new Email("dd@ee.ff", "ee.ff")},
+                List.of(new Phone("123456789", "+11"), new Phone("987654321", "+22")));
+    }
+
+    private Person createPersonWithIncorrectEmailAndPhone() {
+        return new Person(
+                "John",
+                new Address("Main Street", new City("Paris", 75000), "France"),
+                35,
+                new Email[]{new Email("aa/bb.com", "bb.cc"), new Email("aa@bb.com", "bb.cc")},
+                List.of(new Phone("123456789", "+11"), new Phone("987654321", "-22")));
+    }
+
+
+
+    private BValidatorBuilderImpl<Person> createCompleteBuilder(){
+        return new BValidatorBuilderImpl<Person>()
+                .setBusinessObjectName("Person")
+                .addRule("ageValid", Person::isAgeValid, "Name must not be null")
+                .addRule("NameNotEmpty", Person::isNameValid, "Name must not be empty")
+                .addRule("ValidEmail", Person::isEmailValid, "Email must be valid")
+                .addMember("address", Person::getAddress, new BValidatorBuilderImpl<Address>()
+                        .setBusinessObjectName("Address")
+                        .addRule("cityValid", Address::isCityValid, "City must not be null")
+                        .addRule("StreetValid", Address::isStreetValid, "Street must not be empty")
+                        .addMember("city", Address::getCity,  new BValidatorBuilderImpl<City>()
+                                .setBusinessObjectName("City")
+                                .addRule("cityNameValid", City::isNamesValid, "City name must not be empty")
+                                .addRule("cityZipcodeValid", City::isZipCodeValid, "City zipcode must be valid")
+                                )
+                        )
+                .addMember("phones", Person::getPhones,  new BValidatorBuilderImpl<Phone>()
+                        .setBusinessObjectName("Phone")
+                        .addRule("numberValid", Phone::isNumberValid, "Number must not be null")
+                        .addRule("countryCodeValid", Phone::isCountryCodeValid, "Country code must not be valid")
+                        )
+                .addMember("emails", Person::getEmails, new BValidatorBuilderImpl<Email>()
+                        .setBusinessObjectName("Email")
+                        .addRule("emailValid", Email::isEmailValid, "Email must be valid")
+                        .addRule("domainValid", Email::isDomainValid, "Domain must be valid")
+                        );
+    }
+
+
+
+}

--- a/src/test/java/io/github/ceoche/bvalid/BasicRulesTest.java
+++ b/src/test/java/io/github/ceoche/bvalid/BasicRulesTest.java
@@ -25,7 +25,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BasicRulesTest {
 

--- a/src/test/java/io/github/ceoche/bvalid/BusinessObjectMocks.java
+++ b/src/test/java/io/github/ceoche/bvalid/BusinessObjectMocks.java
@@ -26,51 +26,51 @@ import java.util.concurrent.LinkedTransferQueue;
 
 public class BusinessObjectMocks {
 
-   public static Object instantiateValid() {
+   public static DefaultValidableMock instantiateValid() {
       DefaultValidableMock object = new DefaultValidableMock();
       object.setMandatoryAttribute("name");
       object.getOneOrMoreAssociation().add("one association");
       return object;
    }
 
-   public static Object instantiateInvalid() {
+   public static DefaultValidableMock instantiateInvalid() {
       DefaultValidableMock object = new DefaultValidableMock();
       object.setMandatoryAttribute(null);
       object.setOptionalAttribute("   ");
       return object;
    }
 
-   public static Object instantiateInheritanceWithInvalidParent() {
+   public static WithInheritance instantiateInheritanceWithInvalidParent() {
       WithInheritance object = new WithInheritance();
       object.setSubtype("defined sub type");
       object.setMandatoryAttribute(null);
       return object;
    }
 
-   public static Object instantiateInheritanceWithoutAnnotationValid() {
+   public static DefaultValidableMock instantiateInheritanceWithoutAnnotationValid() {
       WithInheritanceButWithoutAnnotation object = new WithInheritanceButWithoutAnnotation();
       object.setMandatoryAttribute("name");
       object.getOneOrMoreAssociation().add("one association");
       return object;
    }
 
-   public static Object instantiateWithoutAssertions() {
+   public static IllegalBusinessObject instantiateWithoutAssertions() {
       IllegalBusinessObject object= new IllegalBusinessObject();
       object.setName("value");
       return object;
    }
 
-   public static Object instantiateBusinessMemberInvalid() {
+   public static OnlyBusinessMembers instantiateBusinessMemberInvalid() {
       OnlyBusinessMembers onlyBusinessMembers = new OnlyBusinessMembers();
       onlyBusinessMembers.setValidableMock((DefaultValidableMock) instantiateInvalid());
       return onlyBusinessMembers;
    }
 
-   public static Object instantiateBusinessMemberNull() {
+   public static OnlyBusinessMembers instantiateBusinessMemberNull() {
       return new OnlyBusinessMembers();
    }
 
-   public static Object instantiateBusinessMemberCollection() {
+   public static CollectionBusinessMembers instantiateBusinessMemberCollection() {
       DefaultValidableMock validMock = (DefaultValidableMock) instantiateValid();
       DefaultValidableMock invalidMock = (DefaultValidableMock) instantiateInvalid();
       CollectionBusinessMembers collecBusinessMember = new CollectionBusinessMembers();
@@ -80,7 +80,7 @@ public class BusinessObjectMocks {
       return collecBusinessMember;
    }
 
-   public static Object instantiateBusinessMemberArray() {
+   public static ArrayBusinessMember instantiateBusinessMemberArray() {
       DefaultValidableMock validMock = (DefaultValidableMock) instantiateValid();
       DefaultValidableMock invalidMock = (DefaultValidableMock) instantiateInvalid();
       ArrayBusinessMember arrayBusinessMember = new ArrayBusinessMember();
@@ -88,21 +88,29 @@ public class BusinessObjectMocks {
       return arrayBusinessMember;
    }
 
-   public static Object instantiateIllegalBusinessRule() {
+   public static IllegalBusinessRuleObject instantiateIllegalBusinessRule() {
       return new IllegalBusinessRuleObject();
    }
 
-   public static Object instantiateIllegalBusinessMember() {
+   public static IllegalBusinessMemberObject instantiateIllegalBusinessMember() {
       return new IllegalBusinessMemberObject();
    }
 
-   public static Object instantiateExceptionBusinessRule() {
+   public static ExceptionBusinessRuleObject instantiateExceptionBusinessRule() {
       return new ExceptionBusinessRuleObject();
    }
 
-   public static Object instantiateExceptionBusinessMember() {
+   public static ExceptionBusinessMemberObject instantiateExceptionBusinessMember() {
       return new ExceptionBusinessMemberObject();
    }
+
+    public static BusinessObjectWithNoAnnotation instantiateBusinessObjectWithNoAnnotation() {
+        BusinessObjectWithNoAnnotation object = new BusinessObjectWithNoAnnotation();
+        object.setName("noAnnotation");
+        object.setMandatoryAttribute("mandatory");
+        object.getOneOrMoreAssociation().add("one association");
+        return object;
+    }
 
    @BusinessObject(name = "validable-mock")
    public static class DefaultValidableMock {
@@ -286,11 +294,30 @@ public class BusinessObjectMocks {
    }
 
    @BusinessObject
-   private static class ExceptionBusinessMemberObject {
+   public static class ExceptionBusinessMemberObject {
 
       @BusinessMember
       public DefaultValidableMock getMember() {
          throw new IllegalStateException();
       }
+   }
+
+   public static class BusinessObjectWithNoAnnotation extends DefaultValidableMock {
+
+      private String name;
+
+      public String getName() {
+         return name;
+      }
+
+      public void setName(String name) {
+         this.name = name;
+      }
+
+      @BusinessRule(description = "The object name must be defined")
+      public boolean isNameValid() {
+          return name != null && !name.isEmpty();
+      }
+
    }
 }

--- a/src/test/java/io/github/ceoche/bvalid/BusinessObjectMocks.java
+++ b/src/test/java/io/github/ceoche/bvalid/BusinessObjectMocks.java
@@ -16,12 +16,7 @@
 
 package io.github.ceoche.bvalid;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Queue;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.LinkedTransferQueue;
 
 public class BusinessObjectMocks {

--- a/src/test/java/io/github/ceoche/bvalid/ObjectResultTest.java
+++ b/src/test/java/io/github/ceoche/bvalid/ObjectResultTest.java
@@ -1,6 +1,9 @@
 package io.github.ceoche.bvalid;
 
-import io.github.ceoche.bvalid.mock.*;
+import io.github.ceoche.bvalid.mock.Address;
+import io.github.ceoche.bvalid.mock.City;
+import io.github.ceoche.bvalid.mock.Person;
+import io.github.ceoche.bvalid.mock.Phone;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/io/github/ceoche/bvalid/ObjectResultTest.java
+++ b/src/test/java/io/github/ceoche/bvalid/ObjectResultTest.java
@@ -1,0 +1,112 @@
+package io.github.ceoche.bvalid;
+
+import io.github.ceoche.bvalid.mock.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ObjectResultTest {
+
+    private static BValidator<Address> addressValidator;
+
+    private static BValidator<Person> personValidatorWithPhones;
+
+    @BeforeAll
+    public static void setUp() {
+        addressValidator = new BValidatorManualBuilder<Address>()
+                .setBusinessObjectName("Address")
+                .addRule("cityValid", Address::isCityValid, "City must not be null")
+                .addRule("StreetValid", Address::isStreetValid, "Street must not be empty")
+                .addMember("city", Address::getCity, new BValidatorManualBuilder<City>()
+                        .setBusinessObjectName("city")
+                        .addRule("cityNameValid", City::isNamesValid, "City name must not be empty")
+                        .addRule("cityZipcodeValid", City::isZipCodeValid, "City zipcode must be valid")
+                )
+                .build();
+        personValidatorWithPhones = new BValidatorManualBuilder<Person>()
+                .setBusinessObjectName("Person")
+                .addMember("phones", Person::getPhones, new BValidatorManualBuilder<Phone>()
+                        .setBusinessObjectName("Phone")
+                        .addRule("numberValid", Phone::isNumberValid, "Number must not be null")
+                        .addRule("countryCodeValid", Phone::isCountryCodeValid, "Country code must not be valid")
+                )
+                .build();
+    }
+
+    @Test
+    public void testGetNbOfTests(){
+        BusinessObjectMocks.DefaultValidableMock object = BusinessObjectMocks.instantiateValid();
+        ObjectResult result = new BValidatorAnnotationBuilder<>(BusinessObjectMocks.DefaultValidableMock.class).build().validate(object);
+        assertEquals(3, result.getNbOfTests());
+    }
+
+    @Test
+    public void testToString(){
+        BusinessObjectMocks.DefaultValidableMock object = BusinessObjectMocks.instantiateValid();
+        ObjectResult result = new BValidatorAnnotationBuilder<>(BusinessObjectMocks.DefaultValidableMock.class).build().validate(object);
+        String stringResult = result.toString();
+        assertTrue(stringResult.contains("validable-mock [rule01] mandatoryAttribute must be defined. => true"));
+        assertTrue(stringResult.contains("validable-mock [OneOrMoreAssociationValid] oneOrMoreAssociation must have at least one element. => true"));
+        assertTrue(stringResult.contains("validable-mock [OptionalAttributeValid] optionalAttribute must be defined if present. => true"));
+    }
+
+    @Test
+    public void testGetRuleResultCorrect(){
+        BusinessObjectMocks.DefaultValidableMock object = BusinessObjectMocks.instantiateValid();
+        ObjectResult result = new BValidatorAnnotationBuilder<>(BusinessObjectMocks.DefaultValidableMock.class).build().validate(object);
+        RuleResult ruleResult = result.getRuleResult("validable-mock [rule01]");
+        assertTrue(ruleResult.isValid());
+    }
+
+    @Test
+    public void testGetRuleResultIncorrectRoot(){
+        BusinessObjectMocks.DefaultValidableMock object = BusinessObjectMocks.instantiateValid();
+        object.setMandatoryAttribute("  ");
+        ObjectResult result = new BValidatorAnnotationBuilder<>(BusinessObjectMocks.DefaultValidableMock.class).build().validate(object);
+        Throwable throwable = assertThrows(IllegalArgumentException.class ,() -> result.getRuleResult("wrongRoot [rule01]"));
+        assertEquals("Rule path does not start with the root object name", throwable.getMessage());
+    }
+
+    @Test
+    public void testGetRuleResultIncorrectRule(){
+        BusinessObjectMocks.DefaultValidableMock object = BusinessObjectMocks.instantiateValid();
+        object.setMandatoryAttribute("  ");
+        ObjectResult result = new BValidatorAnnotationBuilder<>(BusinessObjectMocks.DefaultValidableMock.class).build().validate(object);
+        assertNull(result.getRuleResult("validable-mock [wrongRule]"));
+    }
+
+    @Test
+    public void testGetRuleResultWithMemberCorrect(){
+        Address address = new Address("street", new City("city",-12345), "country");
+        ObjectResult result = addressValidator.validate(address);
+        assertTrue(result.getRuleResult("Address [cityValid]").isValid());
+        assertTrue(result.getRuleResult("Address [StreetValid]").isValid());
+        assertTrue(result.getRuleResult("Address.city [cityNameValid]").isValid());
+        assertFalse(result.getRuleResult("Address.city [cityZipcodeValid]").isValid());
+    }
+
+    @Test
+    public void testGetRuleResultWithMemberIncorrect(){
+        Address address = new Address("street", new City("",-12345), "country");
+        ObjectResult result = addressValidator.validate(address);
+        Throwable throwable = assertThrows(IllegalArgumentException.class ,() -> result.getRuleResult("Address.wrongMember [cityNameValid]"));
+        assertEquals("Rule path does not match any member", throwable.getMessage());
+    }
+
+    @Test
+    public void testGetRuleResultWithListMemberCorrect(){
+        Person person = new Person(null,null,null,null,
+                List.of(new Phone("123456789", "+33"), new Phone("987654321", "aa"))
+        );
+        ObjectResult result = personValidatorWithPhones.validate(person);
+        System.out.println(result);
+        assertTrue(result.getRuleResult("Person.phones[0] [numberValid]").isValid());
+        assertTrue(result.getRuleResult("Person.phones[0] [countryCodeValid]").isValid());
+        assertTrue(result.getRuleResult("Person.phones[1] [numberValid]").isValid());
+        assertFalse(result.getRuleResult("Person.phones[1] [countryCodeValid]").isValid());
+    }
+
+}

--- a/src/test/java/io/github/ceoche/bvalid/ObjectResultTest.java
+++ b/src/test/java/io/github/ceoche/bvalid/ObjectResultTest.java
@@ -16,19 +16,19 @@ public class ObjectResultTest {
 
     @BeforeAll
     public static void setUp() {
-        addressValidator = new BValidatorManualBuilder<Address>()
+        addressValidator = new BValidatorManualBuilder<>(Address.class)
                 .setBusinessObjectName("Address")
                 .addRule("cityValid", Address::isCityValid, "City must not be null")
                 .addRule("StreetValid", Address::isStreetValid, "Street must not be empty")
-                .addMember("city", Address::getCity, new BValidatorManualBuilder<City>()
+                .addMember("city", Address::getCity, new BValidatorManualBuilder<>(City.class)
                         .setBusinessObjectName("city")
                         .addRule("cityNameValid", City::isNamesValid, "City name must not be empty")
                         .addRule("cityZipcodeValid", City::isZipCodeValid, "City zipcode must be valid")
                 )
                 .build();
-        personValidatorWithPhones = new BValidatorManualBuilder<Person>()
+        personValidatorWithPhones = new BValidatorManualBuilder<>(Person.class)
                 .setBusinessObjectName("Person")
-                .addMember("phones", Person::getPhones, new BValidatorManualBuilder<Phone>()
+                .addMember("phones", Person::getPhones, new BValidatorManualBuilder<>(Phone.class)
                         .setBusinessObjectName("Phone")
                         .addRule("numberValid", Phone::isNumberValid, "Number must not be null")
                         .addRule("countryCodeValid", Phone::isCountryCodeValid, "Country code must not be valid")

--- a/src/test/java/io/github/ceoche/bvalid/mock/Address.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/Address.java
@@ -1,8 +1,5 @@
 package io.github.ceoche.bvalid.mock;
 
-import io.github.ceoche.bvalid.BusinessObject;
-import io.github.ceoche.bvalid.BusinessRule;
-
 public class Address {
 
     private final String street;

--- a/src/test/java/io/github/ceoche/bvalid/mock/Address.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/Address.java
@@ -1,0 +1,42 @@
+package io.github.ceoche.bvalid.mock;
+
+import io.github.ceoche.bvalid.BusinessObject;
+import io.github.ceoche.bvalid.BusinessRule;
+
+public class Address {
+
+    private final String street;
+    private final City city;
+    private final String country;
+
+    public Address(String street, City city, String country) {
+        this.street = street;
+        this.city = city;
+        this.country = country;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public City getCity() {
+        return city;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public Boolean isStreetValid() {
+        return street != null && !street.isEmpty();
+    }
+
+    public Boolean isCityValid() {
+        return city != null;
+    }
+
+    public Boolean isCountryValid() {
+        return country != null && !country.isEmpty();
+    }
+
+}

--- a/src/test/java/io/github/ceoche/bvalid/mock/Circle.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/Circle.java
@@ -1,0 +1,53 @@
+package io.github.ceoche.bvalid.mock;
+
+public class Circle extends Shape {
+
+    private  int radius;
+    private  int ox;
+    private  int oy;
+
+
+    public int getRadius() {
+        return radius;
+    }
+
+    public int getOx() {
+        return ox;
+    }
+
+    public int getOy() {
+        return oy;
+    }
+
+    @Override
+    public Circle setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    public Circle setRadius(int radius) {
+        this.radius = radius;
+        return this;
+    }
+
+    public Circle setOx(int ox) {
+        this.ox = ox;
+        return this;
+    }
+
+    public Circle setOy(int oy) {
+        this.oy = oy;
+        return this;
+    }
+
+    public boolean isRadiusValid() {
+        return radius > 0;
+    }
+
+    public boolean isOxValid() {
+        return ox > 0;
+    }
+
+
+
+}

--- a/src/test/java/io/github/ceoche/bvalid/mock/City.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/City.java
@@ -1,7 +1,5 @@
 package io.github.ceoche.bvalid.mock;
 
-import io.github.ceoche.bvalid.BusinessObject;
-
 public class City {
 
     private final String names;

--- a/src/test/java/io/github/ceoche/bvalid/mock/City.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/City.java
@@ -1,0 +1,31 @@
+package io.github.ceoche.bvalid.mock;
+
+import io.github.ceoche.bvalid.BusinessObject;
+
+public class City {
+
+    private final String names;
+
+    private final Integer zipCode;
+
+    public City(String names, Integer zipCode) {
+        this.names = names;
+        this.zipCode = zipCode;
+    }
+
+    public String getNames() {
+        return names;
+    }
+
+    public Integer getZipCode() {
+        return zipCode;
+    }
+
+    public Boolean isNamesValid() {
+        return names != null && !names.isEmpty();
+    }
+
+    public Boolean isZipCodeValid() {
+        return zipCode != null && zipCode > 0;
+    }
+}

--- a/src/test/java/io/github/ceoche/bvalid/mock/CollectionRecursiveObject.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/CollectionRecursiveObject.java
@@ -1,0 +1,66 @@
+package io.github.ceoche.bvalid.mock;
+
+import java.util.List;
+
+public class CollectionRecursiveObject {
+
+    private String collectionAttr;
+
+    private CollectionRecursiveObject collectionRecursiveObject;
+
+    private FirstRecursiveObject[] firstRecursiveObjects;
+
+    private List<SecondRecursiveObject> secondRecursiveObjects;
+
+    public String getCollectionAttr() {
+        return collectionAttr;
+    }
+
+    public CollectionRecursiveObject setCollectionAttr(String collectionAttr) {
+        this.collectionAttr = collectionAttr;
+        return this;
+    }
+
+    public CollectionRecursiveObject getCollectionRecursiveObject() {
+        return collectionRecursiveObject;
+    }
+
+    public CollectionRecursiveObject setCollectionRecursiveObject(CollectionRecursiveObject collectionRecursiveObject) {
+        this.collectionRecursiveObject = collectionRecursiveObject;
+        return this;
+    }
+
+    public FirstRecursiveObject[] getFirstRecursiveObjects() {
+        return firstRecursiveObjects;
+    }
+
+    public CollectionRecursiveObject setFirstRecursiveObjects(FirstRecursiveObject[] firstRecursiveObjects) {
+        this.firstRecursiveObjects = firstRecursiveObjects;
+        return this;
+    }
+
+    public List<SecondRecursiveObject> getSecondRecursiveObjects() {
+        return secondRecursiveObjects;
+    }
+
+    public CollectionRecursiveObject setSecondRecursiveObjects(List<SecondRecursiveObject> secondRecursiveObjects) {
+        this.secondRecursiveObjects = secondRecursiveObjects;
+        return this;
+    }
+
+    public boolean isCollectionAttrValid() {
+        return collectionAttr != null && !collectionAttr.isEmpty();
+    }
+
+    public boolean isCollectionRecursiveObjectValid() {
+        return collectionRecursiveObject == null || collectionRecursiveObject.isCollectionAttrValid();
+    }
+
+    public boolean isFirstRecursiveObjectsValid() {
+        return firstRecursiveObjects != null && firstRecursiveObjects.length > 0;
+    }
+
+    public boolean isSecondRecursiveObjectsValid() {
+        return secondRecursiveObjects != null && secondRecursiveObjects.size() > 0;
+    }
+}

--- a/src/test/java/io/github/ceoche/bvalid/mock/Email.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/Email.java
@@ -1,0 +1,32 @@
+package io.github.ceoche.bvalid.mock;
+
+import io.github.ceoche.bvalid.BusinessObject;
+import io.github.ceoche.bvalid.BusinessRule;
+
+public class Email {
+
+    private final String email;
+
+    private final String domain;
+
+    public Email(String email, String domain) {
+        this.email = email;
+        this.domain = domain;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public Boolean isEmailValid() {
+        return email != null && !email.isEmpty() && email.contains("@");
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public Boolean isDomainValid() {
+        return domain != null && !domain.isEmpty() && domain.contains(".");
+    }
+}

--- a/src/test/java/io/github/ceoche/bvalid/mock/Email.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/Email.java
@@ -1,8 +1,5 @@
 package io.github.ceoche.bvalid.mock;
 
-import io.github.ceoche.bvalid.BusinessObject;
-import io.github.ceoche.bvalid.BusinessRule;
-
 public class Email {
 
     private final String email;

--- a/src/test/java/io/github/ceoche/bvalid/mock/FirstRecursiveObject.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/FirstRecursiveObject.java
@@ -1,0 +1,66 @@
+package io.github.ceoche.bvalid.mock;
+
+public class FirstRecursiveObject {
+
+    private String attr1;
+
+    private FirstRecursiveObject firstRecursiveObject;
+
+    private SecondRecursiveObject secondRecursiveObject;
+
+    private Email email;
+
+
+    public String getAttr1() {
+        return attr1;
+    }
+
+    public FirstRecursiveObject setAttr1(String attr1) {
+        this.attr1 = attr1;
+        return this;
+    }
+
+    public FirstRecursiveObject getFirstRecursiveObject() {
+        return firstRecursiveObject;
+    }
+
+    public FirstRecursiveObject setFirstRecursiveObject(FirstRecursiveObject firstRecursiveObject) {
+        this.firstRecursiveObject = firstRecursiveObject;
+        return this;
+    }
+
+    public Email getEmail() {
+        return email;
+    }
+
+    public FirstRecursiveObject setEmail(Email email) {
+        this.email = email;
+        return this;
+    }
+
+    public SecondRecursiveObject getSecondRecursiveObject() {
+        return secondRecursiveObject;
+    }
+
+    public FirstRecursiveObject setSecondRecursiveObject(SecondRecursiveObject secondRecursiveObject) {
+        this.secondRecursiveObject = secondRecursiveObject;
+        return this;
+    }
+
+    public boolean isAttr1Valid() {
+        return attr1 != null && !attr1.isEmpty();
+    }
+
+    public boolean isEmailValid() {
+        return email != null ;
+    }
+
+    public boolean isSecondRecursiveObjectValid() {
+        return secondRecursiveObject != null;
+    }
+
+    public boolean isFirstRecursiveObjectValid() {
+        return firstRecursiveObject == null || firstRecursiveObject.isAttr1Valid();
+    }
+
+}

--- a/src/test/java/io/github/ceoche/bvalid/mock/Graphic.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/Graphic.java
@@ -1,0 +1,98 @@
+package io.github.ceoche.bvalid.mock;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Graphic {
+
+    private final List<Shape> shapeList;
+
+    private Shape[] shapeArray;
+
+    private Square squareOrRectangle;
+
+    private Shape circle;
+
+    private Graphic innerGraphic;
+
+    private String name;
+
+    public Graphic() {
+        this.shapeList = new ArrayList<>();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Graphic setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public List<Shape> getShapeList() {
+        return shapeList;
+    }
+
+    public Graphic addShapeToList(Shape shape) {
+        shapeList.add(shape);
+        return this;
+    }
+
+    public Shape[] getShapeArray() {
+        return shapeArray;
+    }
+
+    public Graphic setShapeArray(Shape[] shapeArray) {
+        this.shapeArray = shapeArray;
+        return this;
+    }
+
+    public Graphic getInnerGraphic() {
+        return innerGraphic;
+    }
+
+    public Graphic setInnerGraphic(Graphic innerGraphic) {
+        this.innerGraphic = innerGraphic;
+        return this;
+    }
+
+    public Square getSquareOrRectangle() {
+        return squareOrRectangle;
+    }
+
+    public Graphic setSquareOrRectangle(Square squareOrRectangle) {
+        this.squareOrRectangle = squareOrRectangle;
+        return this;
+    }
+
+    public Shape getCircle() {
+        return circle;
+    }
+
+    public Graphic setCircle(Shape circle) {
+        this.circle = circle;
+        return this;
+    }
+
+
+    public boolean isNameValid() {
+        return name != null && !name.isEmpty();
+    }
+
+    public boolean isShapeListValid() {
+        return !shapeList.isEmpty();
+    }
+
+    public boolean isShapeArrayValid() {
+        return shapeArray == null || shapeArray.length > 0;
+    }
+
+    public boolean isInnerGraphicValid() {
+        return innerGraphic != null;
+    }
+
+    public boolean isSquareOrRectangleValid() {
+        return squareOrRectangle != null;
+    }
+}

--- a/src/test/java/io/github/ceoche/bvalid/mock/Losange.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/Losange.java
@@ -1,0 +1,19 @@
+package io.github.ceoche.bvalid.mock;
+
+public class Losange extends Rectangle{
+
+
+    private int diagonal;
+
+
+    @Override
+    public Losange setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    public Losange setDiagonal(int diagonal) {
+        this.diagonal = diagonal;
+        return this;
+    }
+}

--- a/src/test/java/io/github/ceoche/bvalid/mock/Person.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/Person.java
@@ -1,9 +1,5 @@
 package io.github.ceoche.bvalid.mock;
 
-import io.github.ceoche.bvalid.BusinessMember;
-import io.github.ceoche.bvalid.BusinessObject;
-import io.github.ceoche.bvalid.BusinessRule;
-
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/test/java/io/github/ceoche/bvalid/mock/Person.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/Person.java
@@ -1,0 +1,62 @@
+package io.github.ceoche.bvalid.mock;
+
+import io.github.ceoche.bvalid.BusinessMember;
+import io.github.ceoche.bvalid.BusinessObject;
+import io.github.ceoche.bvalid.BusinessRule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Person {
+
+    private final String name;
+    private final Address address;
+    private final Integer age;
+    private final Email[] emails;
+    private final List<Phone> phones = new ArrayList<>();
+
+    public Person(String name, Address address, Integer age, Email[] email, List<Phone> phones) {
+        this.name = name;
+        this.address = address;
+        this.age = age;
+        this.emails = email;
+        this.phones.addAll(phones);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public Integer getAge() {
+        return age;
+    }
+
+    public Email[] getEmails() {
+        return emails;
+    }
+
+    public List<Phone> getPhones() {
+        return phones;
+    }
+
+    public Boolean isAgeValid() {
+        return age > 0 && age < 150;
+    }
+
+    public Boolean isNameValid() {
+        return name != null && !name.isEmpty();
+    }
+
+    public Boolean isAddressValid() {
+        return address != null;
+    }
+
+    public Boolean isEmailValid() {
+        return emails != null && emails.length>0;
+    }
+
+}

--- a/src/test/java/io/github/ceoche/bvalid/mock/Phone.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/Phone.java
@@ -1,0 +1,30 @@
+package io.github.ceoche.bvalid.mock;
+
+public class Phone {
+
+    private final String number;
+
+    private final String countryCode;
+
+    public Phone(String number, String countryCode) {
+        this.number = number;
+        this.countryCode = countryCode;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+
+    public Boolean isNumberValid() {
+        return number != null && !number.isEmpty();
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public Boolean isCountryCodeValid() {
+        return countryCode != null && !countryCode.isEmpty() && countryCode.startsWith("+");
+    }
+}

--- a/src/test/java/io/github/ceoche/bvalid/mock/Rectangle.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/Rectangle.java
@@ -1,0 +1,27 @@
+package io.github.ceoche.bvalid.mock;
+
+public class Rectangle extends Square {
+
+    private int height;
+
+
+    public int getHeight() {
+        return height;
+    }
+
+    public Rectangle setHeight(int height) {
+        this.height = height;
+        return this;
+    }
+
+    @Override
+    public Rectangle setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    public boolean isHeightValid() {
+        return height > 0;
+    }
+
+}

--- a/src/test/java/io/github/ceoche/bvalid/mock/SecondRecursiveObject.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/SecondRecursiveObject.java
@@ -1,0 +1,38 @@
+package io.github.ceoche.bvalid.mock;
+
+public class SecondRecursiveObject {
+
+    private  String attr2;
+
+    private FirstRecursiveObject firstRecursiveObject;
+
+    public SecondRecursiveObject() {
+
+    }
+
+    public String getAttr2() {
+        return attr2;
+    }
+
+    public SecondRecursiveObject setAttr2(String attr2) {
+        this.attr2 = attr2;
+        return this;
+    }
+
+    public FirstRecursiveObject getFirstRecursiveObject() {
+        return firstRecursiveObject;
+    }
+
+    public SecondRecursiveObject setFirstRecursiveObject(FirstRecursiveObject firstRecursiveObject) {
+        this.firstRecursiveObject = firstRecursiveObject;
+        return this;
+    }
+
+    public boolean isAttr2Valid() {
+        return attr2 != null && !attr2.isEmpty();
+    }
+
+    public boolean isFirstRecursiveObjectValid() {
+        return firstRecursiveObject != null;
+    }
+}

--- a/src/test/java/io/github/ceoche/bvalid/mock/Shape.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/Shape.java
@@ -1,0 +1,23 @@
+package io.github.ceoche.bvalid.mock;
+
+public abstract class Shape {
+
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public Shape setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public boolean isNameValid() {
+        return name != null && !name.isEmpty();
+    }
+
+    public void draw() {
+        System.out.println("Drawing a shape");
+    }
+}

--- a/src/test/java/io/github/ceoche/bvalid/mock/Square.java
+++ b/src/test/java/io/github/ceoche/bvalid/mock/Square.java
@@ -1,0 +1,27 @@
+package io.github.ceoche.bvalid.mock;
+
+public class Square extends Shape {
+
+    private int side;
+
+
+
+    public int getSide() {
+        return side;
+    }
+
+    public Square setSide(int side) {
+        this.side = side;
+        return this;
+    }
+
+    @Override
+    public Square setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    public boolean isSideValid() {
+        return side > 0;
+    }
+}


### PR DESCRIPTION
**Add Programmatic Validator Builder**
The main purpose of this builder is to decouple the library from the domain object, and move the assembly of validation constraints to lower layers. The annotations usage remains supported alongside the manual builder.

See README.md.